### PR TITLE
#28 Return module nested in another directory

### DIFF
--- a/gradle/task.go
+++ b/gradle/task.go
@@ -44,9 +44,10 @@ lines:
 		var module string
 
 		split := strings.Split(l, ":")
-		if len(split) > 1 {
-			module = split[0]
-			l = split[1]
+		size := len(split)
+		if size > 1 {
+			module = strings.Join(split[:size - 1], ":")
+			l = split[size - 1]
 		}
 		// module removed if any
 		if strings.HasPrefix(l, task.name) {


### PR DESCRIPTION
Steps now should recognize and list modules that are nested inside another directory.

I tested this with `bitrise-step-android-lint` running locally with replaced `go-android` package and seems to be working fine. Can I run any additional tests?

This is the very first thing I wrote in Go 🎉 

fixes #28 