### PR TITLE
Act 465

### DIFF
--- a/cache/cache.go
+++ b/cache/cache.go
@@ -148,7 +148,6 @@ func computeMD5String(filePath string) (string, error) {
 
 func collectExcludePaths(homeDir, projectDir string) []string {
 	excludePths := []string{
-		"~/.gradle/**",
 		"!~/.gradle/daemon/*/daemon-*.out.log", // excludes Gradle daemon logs, like: ~/.gradle/daemon/6.1.1/daemon-3122.out.log
 		"~/.android/build-cache/**",
 		"*.lock",

--- a/cache/cache.go
+++ b/cache/cache.go
@@ -77,7 +77,7 @@ func collectIncludePaths(homeDir, projectDir string, cacheLevel Level) ([]string
 			return nil
 		}
 
-		if !strings.HasSuffix(f.Name(), ".gradle") && !strings.HasSuffix(f.Name(), ".gradle.kts") {
+		if !strings.HasSuffix(f.Name(), ".gradle") && !strings.HasSuffix(f.Name(), ".gradle.kts") && f.Name() != "gradlew-wrapper.properties" {
 			return nil
 		}
 


### PR DESCRIPTION
- Remove `"~/.gradle/**"` ignore pattern, as changes in $HOME/.gradle directorey is indicated by Gradle, Kotlin DSL and `gradlew-wrapper.properties` files
- Add `gradlew-wrapper.properties` to the cache change indicator