### PR TITLE
Fix crash if build-tools dir is empty

### DIFF
--- a/sdk/sdk.go
+++ b/sdk/sdk.go
@@ -64,7 +64,7 @@ func (model *Model) LatestBuildToolsDir() (string, error) {
 		}
 	}
 
-	if latestVersion.String() == "" {
+	if latestVersion == nil || latestVersion.String() == "" {
 		return "", errors.New("failed to find latest build-tools dir")
 	}
 

--- a/sdk/sdk_test.go
+++ b/sdk/sdk_test.go
@@ -31,6 +31,17 @@ func TestLatestBuildToolsDir(t *testing.T) {
 	require.Equal(t, true, strings.Contains(latestBuildToolsDir, filepath.Join("build-tools", "25.0.3")), latestBuildToolsDir)
 }
 
+func TestNoBuildToolsDir(t *testing.T) {
+	tmpDir, err := pathutil.NormalizedOSTempDirPath("")
+	require.NoError(t, err)
+
+	sdk, err := New(tmpDir)
+	require.NoError(t, err)
+
+	_, err = sdk.LatestBuildToolsDir()
+	require.EqualError(t, err, "failed to find latest build-tools dir")
+}
+
 func TestLatestBuildToolPath(t *testing.T) {
 	tmpDir, err := pathutil.NormalizedOSTempDirPath("")
 	require.NoError(t, err)


### PR DESCRIPTION
Fixes https://github.com/bitrise-steplib/steps-sign-apk/issues/41

The crash happened if the `build-tools` dir was empty for some reason.