### PR TITLE
Accept license when installing a package

### DIFF
--- a/sdkmanager/sdkmanager.go
+++ b/sdkmanager/sdkmanager.go
@@ -3,6 +3,7 @@ package sdkmanager
 import (
 	"fmt"
 	"path/filepath"
+	"strings"
 
 	"github.com/bitrise-io/go-android/sdk"
 	"github.com/bitrise-io/go-android/sdkcomponent"
@@ -74,5 +75,8 @@ func (model Model) InstallCommand(component sdkcomponent.Model) command.Command 
 		args := []string{"update", "sdk", "--no-ui", "--all", "--filter", component.GetLegacySDKStylePath()}
 		return model.cmdFactory.Create(model.binPth, args, nil)
 	}
-	return model.cmdFactory.Create(model.binPth, []string{component.GetSDKStylePath()}, nil)
+	cmdOpts := command.Opts{
+		Stdin: strings.NewReader("y"), // Accept license if prompted
+	}
+	return model.cmdFactory.Create(model.binPth, []string{component.GetSDKStylePath()}, &cmdOpts)
 }


### PR DESCRIPTION
### Context

`install-missing-android-tools` step sets stdin on the `Command` returned by this package's `InstallCommand()` method.

https://github.com/bitrise-steplib/steps-install-missing-android-tools/blob/master/androidcomponents/androidcomponents.go#L213

After the recent changes in `go-utils`, it's not possible to change fields of a constructed `command.Command`. Setting the stdin has to be moved inside `InstallCommand()`.

### Changes

Set `stdin` when constructing sdkmanager install commands. Use `y` as the input to accept any unaccepted licenses during install.
