### PR TITLE
Pass additional arguments correctly

### DIFF
--- a/adbmanager/adbmanager.go
+++ b/adbmanager/adbmanager.go
@@ -62,15 +62,12 @@ func (model Model) RunInstrumentedTestsCmd(
 	additionalTestingOptions []string,
 	commandOptions *command.Opts,
 ) command.Command {
-	args := []string{
-		"shell",
-		"am", "instrument",
-		"-w", packageName + "/" + testRunnerClass,
-	}
+	args := []string{"shell", "am", "instrument"}
 	if len(additionalTestingOptions) > 0 {
 		args = append(args, "-e")
 		args = append(args, additionalTestingOptions...)
 	}
+	args = append(args, "-w", packageName+"/"+testRunnerClass)
 	cmd := model.cmdFactory.Create(model.binPth, args, commandOptions)
 	return cmd
 }

--- a/adbmanager/adbmanager.go
+++ b/adbmanager/adbmanager.go
@@ -56,18 +56,38 @@ func (model Model) InstallAPKCmd(pathToAPK string, commandOptions *command.Opts)
 
 // RunInstrumentedTestsCmd builds and returns a `Command` for running instrumented tests on an attached device or emulator.
 // The `Command` can than be run by the consumer without needing to know the implementation details.
+//
+// `additionalTestingOptions` is a list of arbitrary key value pairs to be passed to the test runner.
+//
+// Example:
+//
+// If a value of `KEY1 true KEY2 false` is passed to this input,
+// then it will be passed to the `adb` command like so:
+//
+// adb shell am instrument -e "KEY1" "true" "KEY2" "false" [...]
+//
+// See `adb` documentation for more info: https://developer.android.com/studio/command-line/adb#am
 func (model Model) RunInstrumentedTestsCmd(
 	packageName string,
 	testRunnerClass string,
 	additionalTestingOptions []string,
 	commandOptions *command.Opts,
 ) command.Command {
-	args := []string{"shell", "am", "instrument"}
+	args := []string{
+		"shell",
+		"am",
+		"instrument",
+		"-w", // Tells `am` (activity manager) to wait for instrumentation to finish before returning
+	}
+
 	if len(additionalTestingOptions) > 0 {
 		args = append(args, "-e")
 		args = append(args, additionalTestingOptions...)
 	}
-	args = append(args, "-w", packageName+"/"+testRunnerClass)
+
+	component := packageName + "/" + testRunnerClass
+	args = append(args, component)
+
 	cmd := model.cmdFactory.Create(model.binPth, args, commandOptions)
 	return cmd
 }

--- a/adbmanager/adbmanager.go
+++ b/adbmanager/adbmanager.go
@@ -61,10 +61,10 @@ func (model Model) InstallAPKCmd(pathToAPK string, commandOptions *command.Opts)
 //
 // Example:
 //
-// If a value of `KEY1 true KEY2 false` is passed to this input,
+// If a value of `{"KEY1", "value1", "KEY2", "value2"}` is passed to `additionalTestingOptions`,
 // then it will be passed to the `adb` command like so:
 //
-// adb shell am instrument -e "KEY1" "true" "KEY2" "false" [...]
+// adb shell am instrument -e "KEY1" "value1" "KEY2" "value2" [...]
 //
 // See `adb` documentation for more info: https://developer.android.com/studio/command-line/adb#am
 func (model Model) RunInstrumentedTestsCmd(

--- a/adbmanager/adbmanager_test.go
+++ b/adbmanager/adbmanager_test.go
@@ -1,27 +1,30 @@
 package adbmanager
 
 import (
-	"github.com/bitrise-io/go-utils/v2/env"
-	"github.com/stretchr/testify/require"
 	"testing"
 
 	"github.com/bitrise-io/go-utils/v2/command"
+	"github.com/bitrise-io/go-utils/v2/env"
+	"github.com/stretchr/testify/require"
 )
 
-func TestModel_InstallAPKCmd(t *testing.T) {
+func Test_GivenAPKPath_WhenCreateInstallAPKCmd_ThenCreatesExpectedCommand(t *testing.T) {
 	// Given
 	mockAPKPath := "/path/to/apk"
 
 	// When
-	testCommand := mockModel().InstallAPKCmd(mockAPKPath, &command.Opts{})
+	testCommand := mockModel().InstallAPKCmd(
+		mockAPKPath,
+		&command.Opts{},
+	)
 
 	// Then
-	actualCMDArgs := testCommand.PrintableCommandArgs()
-	expectedCommandArgs := ` "install" "` + mockAPKPath + `"`
-	require.Equal(t, expectedCommandArgs, actualCMDArgs)
+	actualArgs := testCommand.PrintableCommandArgs()
+	expectedArgs := `adb "install" "/path/to/apk"`
+	require.Equal(t, expectedArgs, actualArgs)
 }
 
-func TestModel_RunInstrumentedTestsCmd_WithAdditionalTestingOptions(t *testing.T) {
+func Test_GivenNoAdditionalTestingOptions_WhenCreateRunInstrumentedTestsCmd_ThenCreatesExpectedCommand(t *testing.T) {
 	// Given
 	mockPackageName := "com.package.name"
 	mockTestRunnerClass := "mock.testrunner.class"
@@ -35,21 +38,16 @@ func TestModel_RunInstrumentedTestsCmd_WithAdditionalTestingOptions(t *testing.T
 	)
 
 	// Then
-	actualCMDArgs := testCommand.PrintableCommandArgs()
-	expectedCommandArgs := ` "shell" "am" "instrument" "-w"`
-	expectedCommandArgs += ` "` + mockPackageName + `/` + mockTestRunnerClass + `"`
-	require.Equal(t, expectedCommandArgs, actualCMDArgs)
+	actualArgs := testCommand.PrintableCommandArgs()
+	expectedArgs := `adb "shell" "am" "instrument" "-w" "com.package.name/mock.testrunner.class"`
+	require.Equal(t, expectedArgs, actualArgs)
 }
 
-func TestModel_RunInstrumentedTestsCmd_WithoutAdditionalTestingOptions(t *testing.T) {
+func Test_GivenAdditionalTestingOptions_WhenCreateRunInstrumentedTestsCmd_ThenCreatesExpectedCommand(t *testing.T) {
 	// Given
 	mockPackageName := "com.package.name"
 	mockTestRunnerClass := "mock.testrunner.class"
-	mockTestingOpt1 := "opt1"
-	mockTestingOpt2 := "opt2"
-	mockAdditionalTestingOptions := []string{
-		mockTestingOpt1, mockTestingOpt2,
-	}
+	mockAdditionalTestingOptions := []string{"opt1", "opt2"}
 
 	// When
 	testCommand := mockModel().RunInstrumentedTestsCmd(
@@ -60,18 +58,16 @@ func TestModel_RunInstrumentedTestsCmd_WithoutAdditionalTestingOptions(t *testin
 	)
 
 	// Then
-	actualCMDArgs := testCommand.PrintableCommandArgs()
-	expectedCommandArgs := ` "shell" "am" "instrument" "-w"`
-	expectedCommandArgs += ` "-e" "` + mockTestingOpt1 + `" "` + mockTestingOpt2 + `"`
-	expectedCommandArgs += ` "` + mockPackageName + `/` + mockTestRunnerClass + `"`
-	require.Equal(t, expectedCommandArgs, actualCMDArgs)
+	actualArgs := testCommand.PrintableCommandArgs()
+	expectedArgs := `adb "shell" "am" "instrument" "-w" "-e" "opt1" "opt2" "com.package.name/mock.testrunner.class"`
+	require.Equal(t, expectedArgs, actualArgs)
 }
 
 // Helpers
 
 func mockModel() Model {
 	return Model{
-		binPth:     "",
+		binPth:     "adb",
 		cmdFactory: command.NewFactory(env.NewRepository()),
 	}
 }

--- a/adbmanager/adbmanager_test.go
+++ b/adbmanager/adbmanager_test.go
@@ -1,0 +1,77 @@
+package adbmanager
+
+import (
+	"github.com/bitrise-io/go-utils/v2/env"
+	"github.com/stretchr/testify/require"
+	"testing"
+
+	"github.com/bitrise-io/go-utils/v2/command"
+)
+
+func TestModel_InstallAPKCmd(t *testing.T) {
+	// Given
+	mockAPKPath := "/path/to/apk"
+
+	// When
+	testCommand := mockModel().InstallAPKCmd(mockAPKPath, &command.Opts{})
+
+	// Then
+	actualCMDArgs := testCommand.PrintableCommandArgs()
+	expectedCommandArgs := ` "install" "` + mockAPKPath + `"`
+	require.Equal(t, expectedCommandArgs, actualCMDArgs)
+}
+
+func TestModel_RunInstrumentedTestsCmd_WithAdditionalTestingOptions(t *testing.T) {
+	// Given
+	mockPackageName := "com.package.name"
+	mockTestRunnerClass := "mock.testrunner.class"
+
+	// When
+	testCommand := mockModel().RunInstrumentedTestsCmd(
+		mockPackageName,
+		mockTestRunnerClass,
+		nil,
+		&command.Opts{},
+	)
+
+	// Then
+	actualCMDArgs := testCommand.PrintableCommandArgs()
+	expectedCommandArgs := ` "shell" "am" "instrument" "-w"`
+	expectedCommandArgs += ` "` + mockPackageName + `/` + mockTestRunnerClass + `"`
+	require.Equal(t, expectedCommandArgs, actualCMDArgs)
+}
+
+func TestModel_RunInstrumentedTestsCmd_WithoutAdditionalTestingOptions(t *testing.T) {
+	// Given
+	mockPackageName := "com.package.name"
+	mockTestRunnerClass := "mock.testrunner.class"
+	mockTestingOpt1 := "opt1"
+	mockTestingOpt2 := "opt2"
+	mockAdditionalTestingOptions := []string{
+		mockTestingOpt1, mockTestingOpt2,
+	}
+
+	// When
+	testCommand := mockModel().RunInstrumentedTestsCmd(
+		mockPackageName,
+		mockTestRunnerClass,
+		mockAdditionalTestingOptions,
+		&command.Opts{},
+	)
+
+	// Then
+	actualCMDArgs := testCommand.PrintableCommandArgs()
+	expectedCommandArgs := ` "shell" "am" "instrument" "-w"`
+	expectedCommandArgs += ` "-e" "` + mockTestingOpt1 + `" "` + mockTestingOpt2 + `"`
+	expectedCommandArgs += ` "` + mockPackageName + `/` + mockTestRunnerClass + `"`
+	require.Equal(t, expectedCommandArgs, actualCMDArgs)
+}
+
+// Helpers
+
+func mockModel() Model {
+	return Model{
+		binPth:     "",
+		cmdFactory: command.NewFactory(env.NewRepository()),
+	}
+}


### PR DESCRIPTION
I've learned since adding these `adb` methods that the `am` command expects the "test component" to be the final argument in the list. This currently only matters if additional arguments are passed to the `RunInstrumentedTestsCmd()` method.

Before:

```shell
adb shell am instrument -w <component> -e <additional_args>
```

After:

```shell
adb shell am instrument -w -e <additional_args> <component>
```

## Version

Requires a _PATCH_ [version update](https://semver.org/).

This is a bugfix, because currently, any additional arguments passed are ignored by the `adb` command.

## Changes

- Moves the test component to being the last item added to the `adb` command's arguments.
- Adds some clarifying documentation.