### PR TITLE
Stop invoking bitrise cache for `tasks` Gradle task. 

### DIFF
--- a/gradle/task.go
+++ b/gradle/task.go
@@ -18,7 +18,7 @@ type Task struct {
 // GetVariants ...
 func (task *Task) GetVariants(args ...string) (Variants, error) {
 	opts := command.Opts{Dir: task.project.location}
-	args = append([]string{"tasks", "--all", "--console=plain", "--quiet"}, args...)
+	args = append([]string{"tasks", "--all", "--console=plain", "--quiet", "--no-build-cache"}, args...)
 	cmd := task.project.cmdFactory.Create(filepath.Join(task.project.location, "gradlew"), args, &opts)
 	tasksOutput, err := cmd.RunAndReturnTrimmedCombinedOutput()
 	if err != nil {


### PR DESCRIPTION
I was poking around at the cache utilization diagnostics where I work and noticed a rather interesting trend: approximately 25% of our cache invocations were for `tasks --all`, a gradle task that the diagnostics report is not cacheable because it takes the entire project state as an input:

![image](https://github.com/user-attachments/assets/09f4a22a-8b61-4469-b489-7684a31b7799)

We don't directly invoke the `tasks` task in any of our workflows, so I started tracing it down and found that it was mostly called by the Android lint and unit test Bitrise steps. Those steps in turn make use of the `GetVariants` function defined in this repository, which appears to be where `tasks --all` is invoked. 

Passing the `--no-build-cache` flag to Gradle at execution time should disable the build cache for the `tasks` task and fix the problem. There may be a _slight_ risk that this increases build times for customers with significantly complex `buildSrc` or included build logic, but in testing with a local cache in our project I couldn't figure out a way to cause those tasks to come from the cache anyways. 

This may also might not be the only solution, there'd be several efficient ways to do this with a custom Gradle plugin, this is just what appeared to me to be the simplest solution given my lack of experience with the step framework