### PR TITLE
Add v2+ signature parsing

### DIFF
--- a/metaparser/aab.go
+++ b/metaparser/aab.go
@@ -1,6 +1,8 @@
 package metaparser
 
 import (
+	"errors"
+
 	"github.com/bitrise-io/go-android/v2/metaparser/androidartifact"
 	"github.com/bitrise-io/go-android/v2/metaparser/androidsignature"
 )
@@ -21,9 +23,9 @@ func (m *Parser) ParseAABData(pth string) (*ArtifactMetadata, error) {
 
 	info := androidartifact.ParseArtifactPath(pth)
 
-	signature, err := androidsignature.Read(pth)
-	if err != nil {
-		m.logger.Warnf("Failed to read signature: %s", err)
+	signature, err := androidsignature.ReadAABSignature(pth)
+	if err != nil && !errors.Is(err, androidsignature.NotVerifiedError) {
+		m.logger.Warnf("Failed to read signature of `%s`: %s", pth, err)
 	}
 
 	return &ArtifactMetadata{

--- a/metaparser/aab.go
+++ b/metaparser/aab.go
@@ -1,8 +1,6 @@
 package metaparser
 
 import (
-	"errors"
-
 	"github.com/bitrise-io/go-android/v2/metaparser/androidartifact"
 	"github.com/bitrise-io/go-android/v2/metaparser/androidsignature"
 )
@@ -24,8 +22,8 @@ func (m *Parser) ParseAABData(pth string) (*ArtifactMetadata, error) {
 	info := androidartifact.ParseArtifactPath(pth)
 
 	signature, err := androidsignature.ReadAABSignature(pth)
-	if err != nil && !errors.Is(err, androidsignature.NotVerifiedError) {
-		m.logger.Warnf("Failed to read signature of `%s`: %s", pth, err)
+	if err != nil {
+		m.logger.Warnf("Failed to get signature of `%s`: %s", pth, err)
 	}
 
 	return &ArtifactMetadata{

--- a/metaparser/androidartifact/aab_info_test.go
+++ b/metaparser/androidartifact/aab_info_test.go
@@ -37,7 +37,7 @@ func Test_GetAABInfo(t *testing.T) {
 		t.Fatalf("setup: failed to initialize bundletool, error: %s", err)
 	}
 
-	aapPath := path.Join(tmpDir, "app-bitrise-signed.aab")
+	aapPath := path.Join(tmpDir, "aab", "app-weak-algorithm-signed.aab")
 	got, err := GetAABInfo(bt, aapPath)
 	if err != nil {
 		t.Fatalf("GetAABInfo() error = %v", err)

--- a/metaparser/androidsignature/signature.go
+++ b/metaparser/androidsignature/signature.go
@@ -13,6 +13,7 @@ import (
 )
 
 const (
+	unsignedJarSignatureMessage = "jar is unsigned"
 	validJarSignatureMessage    = "jar verified"
 	validV2PlusSignatureMessage = "Verifies"
 )
@@ -127,6 +128,10 @@ func getJarSignature(path string) (string, error) {
 
 	// TODO: tmp debug log
 	fmt.Println(output)
+
+	if strings.Contains(output, unsignedJarSignatureMessage) {
+		return "", NoSignatureFoundError
+	}
 
 	if !strings.Contains(output, validJarSignatureMessage) {
 		return "", NotVerifiedError

--- a/metaparser/androidsignature/signature.go
+++ b/metaparser/androidsignature/signature.go
@@ -125,6 +125,9 @@ func getJarSignature(path string) (string, error) {
 		return "", err
 	}
 
+	// TODO: tmp debug log
+	fmt.Println(output)
+
 	if !strings.Contains(output, validJarSignatureMessage) {
 		return "", NotVerifiedError
 	}

--- a/metaparser/androidsignature/signature.go
+++ b/metaparser/androidsignature/signature.go
@@ -126,9 +126,6 @@ func getJarSignature(path string) (string, error) {
 		return "", err
 	}
 
-	// TODO: tmp debug log
-	fmt.Println(output)
-
 	if strings.Contains(output, unsignedJarSignatureMessage) {
 		return "", NoSignatureFoundError
 	}

--- a/metaparser/androidsignature/signature.go
+++ b/metaparser/androidsignature/signature.go
@@ -1,27 +1,138 @@
 package androidsignature
 
 import (
+	"errors"
+	"fmt"
+	"os"
 	"regexp"
 	"strings"
 
+	"github.com/bitrise-io/go-android/v2/sdk"
 	"github.com/bitrise-io/go-utils/command"
 )
 
 const (
-	validSignatureMessage = "jar verified"
+	validJarSignatureMessage    = "jar verified"
+	validV2PlusSignatureMessage = "Verifies"
+)
+
+var (
+	NotVerifiedError = errors.New("not verified")
 )
 
 // Read ...
+//
+// Deprecated: Read is deprecated. Use ReadAABSignature method instead.
 func Read(path string) (string, error) {
-	cmd := signatureCheckCommand(path)
-	output, err := cmd.RunAndReturnTrimmedCombinedOutput()
+	return ReadAABSignature(path)
+}
+
+// ReadAABSignature ...
+func ReadAABSignature(path string) (string, error) {
+	return getJarSignature(path)
+}
+
+// ReadAPKSignature ...
+func ReadAPKSignature(path string) (string, []error) {
+	var signature string
+	var errs []error
+	signature, err := getV4Signature(path)
+	if err != nil {
+		errs = append(errs, fmt.Errorf("v4 signature: %+v", err))
+	}
+	if signature != "" {
+		return signature, errs
+	}
+
+	signature, err = getV23Signature(path)
+	if err != nil {
+		errs = append(errs, fmt.Errorf("v2/v3 signature: %+v", err))
+	}
+	if signature != "" {
+		return signature, errs
+	}
+
+	signature, err = getJarSignature(path)
+	if err != nil {
+		errs = append(errs, fmt.Errorf("jar (v1) signature: %+v", err))
+	}
+
+	return signature, errs
+}
+
+func getV4Signature(path string) (string, error) {
+	idSigPath := path + ".idsig"
+
+	if _, err := os.Stat(idSigPath); errors.Is(err, os.ErrNotExist) {
+		return "", fmt.Errorf("failed to find the v4 signature file (*.idsig), error: %s", err)
+	}
+
+	pathParams := []string{"-v4-signature-file", idSigPath, path}
+	return getV2PlusSignature(pathParams)
+}
+
+func getV23Signature(path string) (string, error) {
+	pathParams := []string{path}
+	return getV2PlusSignature(pathParams)
+}
+
+func getV2PlusSignature(pathParams []string) (string, error) {
+	sdkModel, err := sdk.NewDefaultModel(sdk.Environment{
+		AndroidHome:    os.Getenv("ANDROID_HOME"),
+		AndroidSDKRoot: os.Getenv("ANDROID_SDK_ROOT"),
+	})
+	if err != nil {
+		return "", fmt.Errorf("failed to create sdk model, error: %s", err)
+	}
+
+	apkSignerPath, err := sdkModel.LatestBuildToolPath("apksigner")
+	if err != nil {
+		return "", fmt.Errorf("failed to find latest aapt binary, error: %s", err)
+	}
+
+	params := append([]string{"verify", "--print-certs", "-v"}, pathParams...)
+	apkSignerOutput, err := command.New(apkSignerPath, params...).RunAndReturnTrimmedCombinedOutput()
+	if err != nil {
+		if err.Error() == "exit status 1" {
+			regex := regexp.MustCompile(`DOES NOT VERIFY`)
+			sig := regex.FindString(apkSignerOutput)
+			if sig != "" {
+				return "", NotVerifiedError
+			}
+		}
+		return "", err
+	}
+
+	var signature string
+
+	if strings.Contains(apkSignerOutput, validV2PlusSignatureMessage) {
+		// The signature details appear in the output in the following format:
+		// Signer #1 certificate DN: C=Aa, ST=Bbbbb, L=Ccccc, O=Ddddd, OU=Eeeee, CN=Fffff
+		// Signer #1 certificate SHA-256 digest: <hash>
+		// Signer #1 certificate SHA-1 digest: <hash>
+		// Signer #1 certificate MD5 digest: <hash>
+		regex := regexp.MustCompile("Signer #1 certificate DN: (.*)")
+		res := regex.FindAllStringSubmatch(apkSignerOutput, 1)
+		if len(res) > 0 && len(res[0]) > 1 {
+			return res[0][1], nil
+		}
+	} else {
+		err = NotVerifiedError
+	}
+
+	return signature, err
+}
+
+func getJarSignature(path string) (string, error) {
+	params := []string{"-verify", "-certs", "-verbose", path}
+	output, err := command.New("jarsigner", params...).RunAndReturnTrimmedCombinedOutput()
 	if err != nil {
 		return "", err
 	}
 
 	var signature string
 
-	if strings.Contains(output, validSignatureMessage) {
+	if strings.Contains(output, validJarSignatureMessage) {
 		// The signature details appear in the output in the following format:
 		// - Signed by "C=Aa, ST=Bbbbb, L=Ccccc, O=Ddddd, OU=Eeeee, CN=Fffff"
 		regex := regexp.MustCompile(`- Signed by ".*"`)
@@ -30,12 +141,9 @@ func Read(path string) (string, error) {
 			signature = strings.TrimPrefix(sig, "- Signed by \"")
 			signature = strings.TrimSuffix(signature, "\"")
 		}
+	} else {
+		err = NotVerifiedError
 	}
 
-	return signature, nil
-}
-
-func signatureCheckCommand(path string) *command.Model {
-	params := []string{"-verify", "-certs", "-verbose", path}
-	return command.New("jarsigner", params...)
+	return signature, err
 }

--- a/metaparser/androidsignature/signature.go
+++ b/metaparser/androidsignature/signature.go
@@ -25,19 +25,21 @@ var (
 
 // Read ...
 //
-// Deprecated: Read is deprecated. Use ReadAABSignature method instead.
+// Deprecated: Read is deprecated. Use ReadAABSignature or ReadAPKSignature method instead.
 func Read(path string) (string, error) {
 	return ReadAABSignature(path)
 }
 
 // ReadAABSignature returns the signature of the provided AAB file.
-// If the AAB is not signed, it returns a NotVerifiedError.
+// If the signature can't be read (unsigned, unexpected certificate printing format, ...), it returns a NoSignatureFoundError.
+// If the signature is not verified, it returns a NotVerifiedError.
 func ReadAABSignature(path string) (string, error) {
 	return getJarSignature(path)
 }
 
 // ReadAPKSignature returns the signature of the provided APK file.
-// If the APK is not signed, it returns a NotVerifiedError.
+// If the signature can't be read (unsigned, unexpected certificate printing format, ...), it returns a NoSignatureFoundError.
+// If the signature is not verified, it returns a NotVerifiedError.
 func ReadAPKSignature(apkPath string) (string, error) {
 	idSigPath := apkPath + ".idsig"
 	if _, err := os.Stat(idSigPath); err == nil {

--- a/metaparser/androidsignature/signature_test.go
+++ b/metaparser/androidsignature/signature_test.go
@@ -22,7 +22,7 @@ func Test_ReadAABSignature(t *testing.T) {
 
 	gitCommand, err := git.New(tmpDir)
 	require.NoError(t, err)
-	err = gitCommand.Clone("https://github.com/bitrise-io/sample-artifacts.git").Run()
+	err = gitCommand.Clone("https://github.com/bitrise-io/sample-artifacts.git", "-b", "update-aabs").Run()
 	require.NoError(t, err)
 
 	tests := []struct {
@@ -33,8 +33,8 @@ func Test_ReadAABSignature(t *testing.T) {
 	}{
 		{
 			name:          "Reads AAB signature",
-			apkPath:       path.Join(tmpDir, "aab", "app-release-bitrise-signed.aab"),
-			wantSignature: "CN=Bitrise",
+			apkPath:       path.Join(tmpDir, "aab", "app-release.aab"),
+			wantSignature: "O=Bitrise",
 		},
 		{
 			name:      "Returns NotVerified for week signing algorithm",

--- a/metaparser/androidsignature/signature_test.go
+++ b/metaparser/androidsignature/signature_test.go
@@ -29,17 +29,33 @@ func Test_ReadAABSignature(t *testing.T) {
 		name          string
 		apkPath       string
 		wantSignature string
+		wantError     string
 	}{
 		{
 			name:          "Reads AAB signature",
-			apkPath:       path.Join(tmpDir, "app-bitrise-signed.aab"),
+			apkPath:       path.Join(tmpDir, "aab", "app-release-bitrise-signed.aab"),
 			wantSignature: "CN=Bitrise",
+		},
+		{
+			name:      "Returns NotVerified for week signing algorithm",
+			apkPath:   path.Join(tmpDir, "aab", "app-weak-algorithm-signed.aab"),
+			wantError: NotVerifiedError.Error(),
+		},
+		{
+			name:      "Unsigned AAB",
+			apkPath:   path.Join(tmpDir, "aab", "app-release-unsigned.aab"),
+			wantError: NoSignatureFoundError.Error(),
 		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			gotSignature, gotError := ReadAABSignature(tt.apkPath)
-			require.NoError(t, gotError)
+			if tt.wantError != "" {
+				require.EqualError(t, gotError, tt.wantError)
+			} else {
+				require.NoError(t, gotError)
+			}
+
 			require.Equal(t, tt.wantSignature, gotSignature)
 		})
 	}

--- a/metaparser/androidsignature/signature_test.go
+++ b/metaparser/androidsignature/signature_test.go
@@ -1,70 +1,130 @@
 package androidsignature
 
 import (
-	"errors"
 	"os"
 	"path"
-	"strings"
 	"testing"
 
-	"github.com/kr/pretty"
+	"github.com/stretchr/testify/require"
 
 	"github.com/bitrise-io/go-utils/command/git"
-	"github.com/bitrise-io/go-utils/log"
 )
 
-func Test_ReadAPKSignature(t *testing.T) {
+func Test_ReadAABSignature(t *testing.T) {
 	tmpDir, err := os.MkdirTemp("", "")
-	if err != nil {
-		t.Fatalf("setup: failed to create temp dir, error: %s", err)
-	}
+	require.NoError(t, err)
 
 	defer func() {
 		if err := os.RemoveAll(tmpDir); err != nil {
-			log.Warnf("failed to remove temp dir, error: %s", err)
+			t.Logf("failed to remove temp dir, error: %s", err)
 		}
 	}()
 
 	gitCommand, err := git.New(tmpDir)
-	if err != nil {
-		t.Fatalf("setup: failed to create git project, error: %s", err)
-	}
-	if err := gitCommand.Clone("https://github.com/bitrise-io/sample-artifacts.git").Run(); err != nil {
-		t.Fatalf("setup: failed to clone test artifact repo, error: %s", err)
-	}
+	require.NoError(t, err)
+	err = gitCommand.Clone("https://github.com/bitrise-io/sample-artifacts.git").Run()
+	require.NoError(t, err)
 
 	tests := []struct {
-		name            string
-		path            string
-		wantSignature   string
-		wantErrorsCount int
+		name          string
+		apkPath       string
+		idsigPath     string
+		wantSignature string
 	}{
 		{
-			name:            "Return signature by jarsigner",
-			path:            path.Join(tmpDir, "apks", "app-release-v1-signature.apk"),
-			wantSignature:   "O=Bitrise",
-			wantErrorsCount: 2,
+			name:          "Reads AAB signature",
+			apkPath:       path.Join(tmpDir, "app-bitrise-signed.aab"),
+			wantSignature: "CN=Bitrise",
 		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			gotSignature, gotErrors := ReadAPKSignature(tt.path)
-			if diffs := pretty.Diff(gotSignature, tt.wantSignature); len(diffs) > 0 {
-				t.Errorf(
-					"\nReadAPKSignature()\n - got:\t\t%+v\n - want:\t%+v\n diff:\n\t%s",
-					gotSignature,
-					tt.wantSignature,
-					strings.Join(diffs, "\n"),
-				)
+			gotSignature, gotError := ReadAABSignature(tt.apkPath)
+			require.NoError(t, gotError)
+			require.Equal(t, tt.wantSignature, gotSignature)
+		})
+	}
+}
+
+func Test_ReadASignature(t *testing.T) {
+	tmpDir, err := os.MkdirTemp("", "")
+	require.NoError(t, err)
+
+	defer func() {
+		if err := os.RemoveAll(tmpDir); err != nil {
+			t.Logf("failed to remove temp dir, error: %s", err)
+		}
+	}()
+
+	gitCommand, err := git.New(tmpDir)
+	require.NoError(t, err)
+	err = gitCommand.Clone("https://github.com/bitrise-io/sample-artifacts.git").Run()
+	require.NoError(t, err)
+
+	tests := []struct {
+		name          string
+		apkPath       string
+		idsigPath     string
+		wantSignature string
+		wantError     string
+	}{
+		{
+			name:      "Unsigned APK",
+			apkPath:   path.Join(tmpDir, "apks", "app-release-unsigned.apk"),
+			wantError: NotVerifiedError.Error(),
+		},
+		{
+			name:          "Debug signed APK",
+			apkPath:       path.Join(tmpDir, "apks", "app-debug.apk"),
+			wantSignature: "C=US, O=Android, CN=Android Debug",
+		},
+		{
+			name:          "Reads V1 signature",
+			apkPath:       path.Join(tmpDir, "apks", "app-release-v1-signature.apk"),
+			wantSignature: "O=Bitrise",
+		},
+		{
+			name:          "Reads V2 signature",
+			apkPath:       path.Join(tmpDir, "apks", "app-release-v2-signature.apk"),
+			wantSignature: "O=Bitrise",
+		},
+		{
+			name:          "Reads V2+v3 signature",
+			apkPath:       path.Join(tmpDir, "apks", "app-release-v2-v3-signature.apk"),
+			wantSignature: "O=Bitrise",
+		},
+		{
+			name:          "Reads V2+v4 signature",
+			apkPath:       path.Join(tmpDir, "apks", "app-release-v2-v4-signature.apk"),
+			wantSignature: "O=Bitrise",
+		},
+		{
+			name:          "Reads V2+v4 signature with .idsig file",
+			apkPath:       path.Join(tmpDir, "apks", "app-release-v2-v4-signature.apk"),
+			idsigPath:     path.Join(tmpDir, "apks", "app-release-v2-v4-signature.apk.idsig"),
+			wantSignature: "O=Bitrise",
+		},
+		{
+			name:          "Reads V3+v4 signature",
+			apkPath:       path.Join(tmpDir, "apks", "app-release-v3-v4-signature.apk"),
+			wantSignature: "O=Bitrise",
+		},
+		{
+			name:          "Reads V3+v4 signature with .idsig file",
+			apkPath:       path.Join(tmpDir, "apks", "app-release-v3-v4-signature.apk"),
+			idsigPath:     path.Join(tmpDir, "apks", "app-release-v3-v4-signature.apk.idsig"),
+			wantSignature: "O=Bitrise",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			gotSignature, gotError := ReadAPKSignature(tt.apkPath)
+			if tt.wantError != "" {
+				require.EqualError(t, gotError, tt.wantError)
+			} else {
+				require.NoError(t, gotError)
 			}
-			if len(gotErrors) != tt.wantErrorsCount {
-				t.Errorf(
-					"\nReadAPKSignature()\n - got_array:\t\t%+v\n - got:\t\t%+v\n - want:\t%+v",
-					errors.Join(gotErrors...),
-					len(gotErrors),
-					tt.wantErrorsCount,
-				)
-			}
+			require.Equal(t, tt.wantSignature, gotSignature)
 		})
 	}
 }

--- a/metaparser/androidsignature/signature_test.go
+++ b/metaparser/androidsignature/signature_test.go
@@ -61,7 +61,7 @@ func Test_ReadAABSignature(t *testing.T) {
 	}
 }
 
-func Test_ReadASignature(t *testing.T) {
+func Test_ReadAPKSignature(t *testing.T) {
 	tmpDir, err := os.MkdirTemp("", "")
 	require.NoError(t, err)
 
@@ -86,7 +86,7 @@ func Test_ReadASignature(t *testing.T) {
 		{
 			name:      "Unsigned APK",
 			apkPath:   path.Join(tmpDir, "apks", "app-release-unsigned.apk"),
-			wantError: NotVerifiedError.Error(),
+			wantError: NoSignatureFoundError.Error(),
 		},
 		{
 			name:          "Debug signed APK",

--- a/metaparser/androidsignature/signature_test.go
+++ b/metaparser/androidsignature/signature_test.go
@@ -28,7 +28,6 @@ func Test_ReadAABSignature(t *testing.T) {
 	tests := []struct {
 		name          string
 		apkPath       string
-		idsigPath     string
 		wantSignature string
 	}{
 		{

--- a/metaparser/androidsignature/signature_test.go
+++ b/metaparser/androidsignature/signature_test.go
@@ -1,0 +1,70 @@
+package androidsignature
+
+import (
+	"errors"
+	"os"
+	"path"
+	"strings"
+	"testing"
+
+	"github.com/kr/pretty"
+
+	"github.com/bitrise-io/go-utils/command/git"
+	"github.com/bitrise-io/go-utils/log"
+)
+
+func Test_ReadAPKSignature(t *testing.T) {
+	tmpDir, err := os.MkdirTemp("", "")
+	if err != nil {
+		t.Fatalf("setup: failed to create temp dir, error: %s", err)
+	}
+
+	defer func() {
+		if err := os.RemoveAll(tmpDir); err != nil {
+			log.Warnf("failed to remove temp dir, error: %s", err)
+		}
+	}()
+
+	gitCommand, err := git.New(tmpDir)
+	if err != nil {
+		t.Fatalf("setup: failed to create git project, error: %s", err)
+	}
+	if err := gitCommand.Clone("https://github.com/bitrise-io/sample-artifacts.git").Run(); err != nil {
+		t.Fatalf("setup: failed to clone test artifact repo, error: %s", err)
+	}
+
+	tests := []struct {
+		name            string
+		path            string
+		wantSignature   string
+		wantErrorsCount int
+	}{
+		{
+			name:            "Return signature by jarsigner",
+			path:            path.Join(tmpDir, "apks", "app-release-v1-signature.apk"),
+			wantSignature:   "O=Bitrise",
+			wantErrorsCount: 2,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			gotSignature, gotErrors := ReadAPKSignature(tt.path)
+			if diffs := pretty.Diff(gotSignature, tt.wantSignature); len(diffs) > 0 {
+				t.Errorf(
+					"\nReadAPKSignature()\n - got:\t\t%+v\n - want:\t%+v\n diff:\n\t%s",
+					gotSignature,
+					tt.wantSignature,
+					strings.Join(diffs, "\n"),
+				)
+			}
+			if len(gotErrors) != tt.wantErrorsCount {
+				t.Errorf(
+					"\nReadAPKSignature()\n - got_array:\t\t%+v\n - got:\t\t%+v\n - want:\t%+v",
+					errors.Join(gotErrors...),
+					len(gotErrors),
+					tt.wantErrorsCount,
+				)
+			}
+		})
+	}
+}

--- a/metaparser/androidsignature/signature_test.go
+++ b/metaparser/androidsignature/signature_test.go
@@ -22,7 +22,7 @@ func Test_ReadAABSignature(t *testing.T) {
 
 	gitCommand, err := git.New(tmpDir)
 	require.NoError(t, err)
-	err = gitCommand.Clone("https://github.com/bitrise-io/sample-artifacts.git", "-b", "update-aabs").Run()
+	err = gitCommand.Clone("https://github.com/bitrise-io/sample-artifacts.git").Run()
 	require.NoError(t, err)
 
 	tests := []struct {

--- a/metaparser/apk.go
+++ b/metaparser/apk.go
@@ -1,8 +1,6 @@
 package metaparser
 
 import (
-	"fmt"
-
 	"github.com/bitrise-io/go-android/v2/metaparser/androidartifact"
 	"github.com/bitrise-io/go-android/v2/metaparser/androidsignature"
 )
@@ -21,17 +19,9 @@ func (m *Parser) ParseAPKData(pth string) (*ArtifactMetadata, error) {
 
 	info := androidartifact.ParseArtifactPath(pth)
 
-	signature, errs := androidsignature.ReadAPKSignature(pth)
-	if len(errs) > 0 {
-		format := "Failed to read signature of `%s`: \n%s"
-		if signature != "" {
-			format = "Errors during reading the signature of `%s`: \n%s"
-		}
-		var output string
-		for _, err := range errs {
-			output += fmt.Sprintf("- %s\n", err.Error())
-		}
-		m.logger.Warnf(format, pth, output)
+	signature, err := androidsignature.ReadAPKSignature(pth)
+	if err != nil {
+		m.logger.Warnf("Failed to get signature of `%s`: %s", pth, err)
 	}
 
 	return &ArtifactMetadata{

--- a/metaparser/apk.go
+++ b/metaparser/apk.go
@@ -1,7 +1,10 @@
 package metaparser
 
 import (
+	"fmt"
+
 	"github.com/bitrise-io/go-android/v2/metaparser/androidartifact"
+	"github.com/bitrise-io/go-android/v2/metaparser/androidsignature"
 )
 
 // ParseAPKData ...
@@ -18,11 +21,25 @@ func (m *Parser) ParseAPKData(pth string) (*ArtifactMetadata, error) {
 
 	info := androidartifact.ParseArtifactPath(pth)
 
+	signature, errs := androidsignature.ReadAPKSignature(pth)
+	if len(errs) > 0 {
+		format := "Failed to read signature of `%s`: \n%s"
+		if signature != "" {
+			format = "Errors during reading the signature of `%s`: \n%s"
+		}
+		var output string
+		for _, err := range errs {
+			output += fmt.Sprintf("- %s\n", err.Error())
+		}
+		m.logger.Warnf(format, pth, output)
+	}
+
 	return &ArtifactMetadata{
 		AppInfo:        apkInfo,
 		FileSizeBytes:  fileSize,
 		Module:         info.Module,
 		ProductFlavour: info.ProductFlavour,
 		BuildType:      info.BuildType,
+		SignedBy:       signature,
 	}, nil
 }


### PR DESCRIPTION
JIRA: [RA-3288]

ApkParser examples:
V2:
<img width="1048" alt="image" src="https://github.com/user-attachments/assets/e264ccd2-6480-4321-b328-5ef8c2e4ed00" />

V2-3:
<img width="1032" alt="image" src="https://github.com/user-attachments/assets/c696ee5c-a080-4b95-afe9-e964394335c7" />

V2-4:
<img width="1079" alt="image" src="https://github.com/user-attachments/assets/443800d1-856d-4d0b-93be-5d0db3bcbff0" />


Deploy step example outputs:
APK signed with V1:
![image](https://github.com/user-attachments/assets/81e8ef5d-d2ee-4f74-8101-381a6addcaa6)

V2/V3/V4
![image](https://github.com/user-attachments/assets/b875c532-6be7-4dc4-8961-5c731c1470fa)

[RA-3288]: https://bitrise.atlassian.net/browse/RA-3288?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ