### PR TITLE
Introduce InvalidKeystoreFileError

### DIFF
--- a/keystore/keystore.go
+++ b/keystore/keystore.go
@@ -21,6 +21,7 @@ var (
 	IncorrectAliasError            = errors.New("incorrect key alias")
 	IncorrectKeystorePasswordError = errors.New("incorrect keystore password")
 	IncorrectKeyPasswordError      = errors.New("incorrect key password")
+	InvalidKeystoreFileError       = errors.New("invalid keystore file")
 )
 
 type Decoder interface {
@@ -59,6 +60,7 @@ func (p Reader) ReadCertificateInformation(data []byte, password, alias, keyPass
 	}
 
 	if cert == nil && len(decodeErrs) > 0 {
+		// All decoders have failed
 		decodeErrsStr := ""
 		for i, decodeErr := range decodeErrs {
 			decodeErrsStr += "- " + decodeErr.Error()
@@ -66,7 +68,12 @@ func (p Reader) ReadCertificateInformation(data []byte, password, alias, keyPass
 				decodeErrsStr += "\n"
 			}
 		}
-		return nil, fmt.Errorf("failed to decode keystore:\n%s", decodeErrsStr)
+		return nil, fmt.Errorf("%w: failed to decode as PKCS12 or JKS:\n%s", InvalidKeystoreFileError, decodeErrsStr)
+	}
+
+	if cert == nil {
+		// This shouldn't happen
+		return nil, fmt.Errorf("couldn't read certificate")
 	}
 
 	certInfo := parseCertificate(cert)

--- a/keystore/keystore_test.go
+++ b/keystore/keystore_test.go
@@ -1,7 +1,6 @@
 package keystore
 
 import (
-	"errors"
 	"io"
 	"os"
 	"path/filepath"
@@ -18,7 +17,7 @@ func TestParse(t *testing.T) {
 		privateKeyAlias    string
 		privateKeyPassword string
 		want               *CertificateInformation
-		wantError          string
+		wantError          error
 	}{
 		{
 			name:               "PKCS12 keystore test",
@@ -123,7 +122,7 @@ func TestParse(t *testing.T) {
 			password:           "keystore",
 			privateKeyAlias:    "mykey",
 			privateKeyPassword: "keystore",
-			wantError:          InvalidKeystoreFileError.Error(),
+			wantError:          InvalidKeystoreFileError,
 		},
 	}
 	for _, tt := range tests {
@@ -140,9 +139,8 @@ func TestParse(t *testing.T) {
 
 			parser := NewDefaultReader()
 			got, err := parser.ReadCertificateInformation(b, tt.password, tt.privateKeyAlias, tt.privateKeyPassword)
-			if tt.wantError != "" {
-				require.Error(t, err)
-				require.True(t, errors.Is(err, InvalidKeystoreFileError))
+			if tt.wantError != nil {
+				require.ErrorIs(t, err, tt.wantError)
 				require.Nil(t, got)
 			} else {
 				require.NoError(t, err)
@@ -159,7 +157,7 @@ func TestIncorrectKeystoreCredentials(t *testing.T) {
 		password           string
 		privateKeyAlias    string
 		privateKeyPassword string
-		wantError          string
+		wantError          error
 	}{
 		{
 			name:               "PKCS12 keystore test - incorrect password",
@@ -167,7 +165,7 @@ func TestIncorrectKeystoreCredentials(t *testing.T) {
 			password:           "incorrect-password",
 			privateKeyAlias:    "key0",
 			privateKeyPassword: "keypass",
-			wantError:          IncorrectKeystorePasswordError.Error(),
+			wantError:          IncorrectKeystorePasswordError,
 		},
 		{
 			name:               "PKCS12 keystore test - incorrect alias",
@@ -175,7 +173,7 @@ func TestIncorrectKeystoreCredentials(t *testing.T) {
 			password:           "storepass",
 			privateKeyAlias:    "incorrect-alias",
 			privateKeyPassword: "keypass",
-			wantError:          IncorrectAliasError.Error(),
+			wantError:          IncorrectAliasError,
 		},
 		{
 			name:               "PKCS12 keystore test - incorrect key password",
@@ -183,7 +181,7 @@ func TestIncorrectKeystoreCredentials(t *testing.T) {
 			password:           "storepass",
 			privateKeyAlias:    "key0",
 			privateKeyPassword: "incorrect-keypassword",
-			wantError:          IncorrectKeyPasswordError.Error(),
+			wantError:          IncorrectKeyPasswordError,
 		},
 		{
 			name:               "JKS keystore test - incorrect password",
@@ -191,7 +189,7 @@ func TestIncorrectKeystoreCredentials(t *testing.T) {
 			password:           "incorrect-password",
 			privateKeyAlias:    "mykey",
 			privateKeyPassword: "keystore",
-			wantError:          IncorrectKeystorePasswordError.Error(),
+			wantError:          IncorrectKeystorePasswordError,
 		},
 		{
 			name:               "JKS keystore test - incorrect alias",
@@ -199,7 +197,7 @@ func TestIncorrectKeystoreCredentials(t *testing.T) {
 			password:           "keystore",
 			privateKeyAlias:    "incorrect-alias",
 			privateKeyPassword: "keystore",
-			wantError:          IncorrectAliasError.Error(),
+			wantError:          IncorrectAliasError,
 		},
 		{
 			name:               "JKS keystore test - incorrect key password",
@@ -207,7 +205,7 @@ func TestIncorrectKeystoreCredentials(t *testing.T) {
 			password:           "keystore",
 			privateKeyAlias:    "mykey",
 			privateKeyPassword: "incorrect-keypassword",
-			wantError:          IncorrectKeyPasswordError.Error(),
+			wantError:          IncorrectKeyPasswordError,
 		},
 	}
 	for _, tt := range tests {
@@ -224,7 +222,7 @@ func TestIncorrectKeystoreCredentials(t *testing.T) {
 
 			parser := NewDefaultReader()
 			got, err := parser.ReadCertificateInformation(b, tt.password, tt.privateKeyAlias, tt.privateKeyPassword)
-			require.EqualError(t, err, tt.wantError)
+			require.ErrorIs(t, err, tt.wantError)
 			require.Nil(t, got)
 		})
 	}
@@ -238,7 +236,6 @@ func TestIsInvalidCredentialsError(t *testing.T) {
 		password           string
 		privateKeyAlias    string
 		privateKeyPassword string
-		wantError          string
 	}{
 		{
 			name:               "PKCS12 keystore, JKS decoder",
@@ -247,7 +244,6 @@ func TestIsInvalidCredentialsError(t *testing.T) {
 			password:           "storepass",
 			privateKeyAlias:    "key0",
 			privateKeyPassword: "keypass",
-			wantError:          IncorrectKeystorePasswordError.Error(),
 		},
 		{
 			name:               "JKS keystore, PKCS12 decoder",
@@ -256,7 +252,6 @@ func TestIsInvalidCredentialsError(t *testing.T) {
 			password:           "keystore",
 			privateKeyAlias:    "mykey",
 			privateKeyPassword: "keystore",
-			wantError:          IncorrectAliasError.Error(),
 		},
 	}
 	for _, tt := range tests {

--- a/keystore/keystore_test.go
+++ b/keystore/keystore_test.go
@@ -1,10 +1,10 @@
 package keystore
 
 import (
+	"errors"
 	"io"
 	"os"
 	"path/filepath"
-	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -123,7 +123,7 @@ func TestParse(t *testing.T) {
 			password:           "keystore",
 			privateKeyAlias:    "mykey",
 			privateKeyPassword: "keystore",
-			wantError:          "failed to decode keystore:",
+			wantError:          InvalidKeystoreFileError.Error(),
 		},
 	}
 	for _, tt := range tests {
@@ -142,7 +142,7 @@ func TestParse(t *testing.T) {
 			got, err := parser.ReadCertificateInformation(b, tt.password, tt.privateKeyAlias, tt.privateKeyPassword)
 			if tt.wantError != "" {
 				require.Error(t, err)
-				require.True(t, strings.Contains(err.Error(), tt.wantError))
+				require.True(t, errors.Is(err, InvalidKeystoreFileError))
 				require.Nil(t, got)
 			} else {
 				require.NoError(t, err)


### PR DESCRIPTION
**Add `InvalidKeystoreFileError` sentinel**

Adds a new exported sentinel error `InvalidKeystoreFileError` to the keystore package. When `ReadCertificateInformation` fails to decode a file as either PKCS12 or JKS, it now returns this sentinel (wrapped with the decoder errors as context) instead of a plain formatted string. This allows callers to distinguish an unrecognisable file from credential errors using `errors.Is`.