### PR TITLE
chore: migrate sliceutil v1 to v2

### DIFF
--- a/metaparser/androidartifact/file_name.go
+++ b/metaparser/androidartifact/file_name.go
@@ -3,11 +3,11 @@ package androidartifact
 import (
 	"fmt"
 	"path/filepath"
+	"slices"
 	"strings"
 	"unicode"
 
 	"github.com/bitrise-io/go-utils/pretty"
-	"github.com/bitrise-io/go-utils/sliceutil"
 	"github.com/bitrise-io/go-utils/v2/log"
 )
 
@@ -164,7 +164,7 @@ func FindSameArtifact(pth string, pths []string) string {
 		_, base := parseSigningInfo(pth)
 		artifactPth := filepath.Join(filepath.Dir(pth), base+suffix+filepath.Ext(pth))
 
-		if idx := sliceutil.IndexOfStringInSlice(artifactPth, pths); idx > -1 {
+		if idx := slices.Index(pths, artifactPth); idx > -1 {
 			return pths[idx]
 		}
 	}


### PR DESCRIPTION
Replace `github.com/bitrise-io/go-utils/sliceutil` (v1) usages:
- `IsStringInSlice` → `slices.Contains` (stdlib)
- `IndexOfStringInSlice` → `slices.Index` (stdlib)
- `CleanWhitespace` → `sliceutil.Map` + `sliceutil.Filter` (v2)