### PR TITLE
gradle: include full nested module path in artifact names (#67)

### DIFF
--- a/gradle/project.go
+++ b/gradle/project.go
@@ -140,7 +140,11 @@ func (proj Project) extractArtifactName(path string, includeModuleInName bool) (
 	fileName := filepath.Base(relPath)
 
 	if includeModuleInName {
-		fileName = strings.Split(relPath, "/")[0] + "-" + fileName
+		modulePath := strings.Split(relPath, "/")[0]
+		if idx := strings.Index(relPath, "/build/"); idx > 0 {
+			modulePath = strings.ReplaceAll(relPath[:idx], "/", "-")
+		}
+		fileName = modulePath + "-" + fileName
 	}
 
 	if proj.monoRepo {

--- a/gradle/project_test.go
+++ b/gradle/project_test.go
@@ -1,0 +1,79 @@
+package gradle
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestExtractArtifactName(t *testing.T) {
+	tests := []struct {
+		name                string
+		projectLocation     string
+		monoRepo            bool
+		path                string
+		includeModuleInName bool
+		want                string
+	}{
+		{
+			name:                "top-level module without includeModule",
+			projectLocation:     "/repo",
+			path:                "/repo/app/build/outputs/apk/debug/app-debug.apk",
+			includeModuleInName: false,
+			want:                "app-debug.apk",
+		},
+		{
+			name:                "top-level module with includeModule",
+			projectLocation:     "/repo",
+			path:                "/repo/app/build/outputs/apk/debug/app-debug.apk",
+			includeModuleInName: true,
+			want:                "app-app-debug.apk",
+		},
+		{
+			name:                "nested module with includeModule",
+			projectLocation:     "/repo",
+			path:                "/repo/feature/feature-name-1/data/build/outputs/aar/data-debug.aar",
+			includeModuleInName: true,
+			want:                "feature-feature-name-1-data-data-debug.aar",
+		},
+		{
+			name:                "nested module without includeModule",
+			projectLocation:     "/repo",
+			path:                "/repo/feature/feature-name-1/data/build/outputs/aar/data-debug.aar",
+			includeModuleInName: false,
+			want:                "data-debug.aar",
+		},
+		{
+			name:                "monorepo top-level module",
+			projectLocation:     "/repo/android",
+			monoRepo:            true,
+			path:                "/repo/android/app/build/outputs/apk/debug/app-debug.apk",
+			includeModuleInName: true,
+			want:                "android-app-app-debug.apk",
+		},
+		{
+			name:                "monorepo nested module",
+			projectLocation:     "/repo/android",
+			monoRepo:            true,
+			path:                "/repo/android/feature/auth/data/build/outputs/aar/data-release.aar",
+			includeModuleInName: true,
+			want:                "android-feature-auth-data-data-release.aar",
+		},
+		{
+			name:                "artifact not under /build/ falls back to top-level segment",
+			projectLocation:     "/repo",
+			path:                "/repo/app/extra/foo.txt",
+			includeModuleInName: true,
+			want:                "app-foo.txt",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			proj := Project{location: tc.projectLocation, monoRepo: tc.monoRepo}
+			got, err := proj.extractArtifactName(tc.path, tc.includeModuleInName)
+			require.NoError(t, err)
+			require.Equal(t, tc.want, got)
+		})
+	}
+}


### PR DESCRIPTION
## Summary

`Project.extractArtifactName(path, includeModuleInName=true)` only prefixed the artifact filename with the **top-level path segment**:

\`\`\`go
fileName = strings.Split(relPath, "/")[0] + "-" + fileName
\`\`\`

For projects with nested modules this collapses every artifact under the same top-level dir to the same prefix. E.g. given the layout:

\`\`\`
feature/feature-name-1/data/build/outputs/aar/data-debug.aar
feature/feature-name-1/presentation/build/outputs/aar/presentation-debug.aar
feature/feature-name-2/data/build/outputs/aar/data-debug.aar
\`\`\`

all three artifacts got the prefix `feature-` and collided on filename when uploaded to `BITRISE_DEPLOY_DIR`.

Reported by @designedbyz in #67; surfaces in the community Android Detekt step (and any other step relying on `FindArtifacts` / `FindDirs` for naming).

## Change

Extract the module path as everything before `/build/` (the canonical marker of a Gradle module's output root) and join its segments with `-`:

\`\`\`go
modulePath := strings.Split(relPath, "/")[0]
if idx := strings.Index(relPath, "/build/"); idx > 0 {
    modulePath = strings.ReplaceAll(relPath[:idx], "/", "-")
}
fileName = modulePath + "-" + fileName
\`\`\`

For non-nested modules (`app/build/outputs/...`) the result is identical to the previous behavior (`app-...`). For nested modules the prefix now includes the full Gradle module path: `feature-feature-name-1-data-data-debug.aar`. Falls back to the original top-segment behavior when the path does not contain `/build/`.

## Test plan

- [x] New `TestExtractArtifactName` covers: top-level, nested, monorepo top-level, monorepo nested, non-`/build/` fallback, with and without `includeModuleInName`. All pass.
- [x] `go test ./...` — green.
- [x] `go build ./...` — clean.

Closes #67

🤖 Generated with [Claude Code](https://claude.com/claude-code)