### PR TITLE
chore: migrate adbmanager pathutil v1 to v2

### DIFF
--- a/adbmanager/adbmanager.go
+++ b/adbmanager/adbmanager.go
@@ -6,9 +6,9 @@ import (
 	"time"
 
 	"github.com/bitrise-io/go-android/v2/sdk"
-	"github.com/bitrise-io/go-utils/pathutil"
 	"github.com/bitrise-io/go-utils/v2/command"
 	"github.com/bitrise-io/go-utils/v2/log"
+	"github.com/bitrise-io/go-utils/v2/pathutil"
 )
 
 type Model struct {
@@ -19,7 +19,7 @@ type Model struct {
 
 func New(sdk sdk.AndroidSdkInterface, cmdFactory command.Factory, logger log.Logger) (*Model, error) {
 	binPth := filepath.Join(sdk.GetAndroidHome(), "platform-tools", "adb")
-	if exist, err := pathutil.IsPathExists(binPth); err != nil {
+	if exist, err := pathutil.NewPathChecker().IsPathExists(binPth); err != nil {
 		return nil, fmt.Errorf("failed to check if adb exist, error: %s", err)
 	} else if !exist {
 		return nil, fmt.Errorf("adb not exist at: %s", binPth)


### PR DESCRIPTION
## Summary
- Swap `github.com/bitrise-io/go-utils/pathutil` → `github.com/bitrise-io/go-utils/v2/pathutil` in `adbmanager/adbmanager.go`.
- `IsPathExists` lives on `PathChecker` in v2; use `pathutil.NewPathChecker().IsPathExists(...)` inline to keep `New()` signature stable.

Jira: [STEP-2478](https://bitrise.atlassian.net/browse/STEP-2478) (parent [STEP-2380](https://bitrise.atlassian.net/browse/STEP-2380))

## Test plan
- [x] `go build ./...`
- [x] `go test ./adbmanager/...`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[STEP-2478]: https://bitrise.atlassian.net/browse/STEP-2478?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[STEP-2380]: https://bitrise.atlassian.net/browse/STEP-2380?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ