### PR TITLE
chore: migrate sdk pathutil v1 to v2

### DIFF
--- a/sdk/sdk.go
+++ b/sdk/sdk.go
@@ -7,7 +7,7 @@ import (
 	"path/filepath"
 	"strings"
 
-	"github.com/bitrise-io/go-utils/pathutil"
+	"github.com/bitrise-io/go-utils/v2/pathutil"
 	"github.com/hashicorp/go-version"
 )
 
@@ -79,7 +79,7 @@ func validateAndroidSDKRoot(androidSDKRoot string) (string, error) {
 		return "", err
 	}
 
-	if exist, err := pathutil.IsDirExists(evaluatedSDKRoot); err != nil {
+	if exist, err := pathutil.NewPathChecker().IsDirExists(evaluatedSDKRoot); err != nil {
 		return "", err
 	} else if !exist {
 		return "", fmt.Errorf("(%s) is not a valid Android SDK root", evaluatedSDKRoot)
@@ -131,7 +131,7 @@ func (model *Model) LatestBuildToolPath(name string) (string, error) {
 	}
 
 	pth := filepath.Join(buildToolsDir, name)
-	if exist, err := pathutil.IsPathExists(pth); err != nil {
+	if exist, err := pathutil.NewPathChecker().IsPathExists(pth); err != nil {
 		return "", err
 	} else if !exist {
 		return "", fmt.Errorf("tool (%s) not found at: %s", name, buildToolsDir)
@@ -161,7 +161,7 @@ func (model *Model) CmdlineToolsPath() (string, error) {
 		}
 
 		sdkmanagerPath := matches[0]
-		if exists, err := pathutil.IsDirExists(sdkmanagerPath); err != nil {
+		if exists, err := pathutil.NewPathChecker().IsDirExists(sdkmanagerPath); err != nil {
 			warnings = append(warnings, fmt.Sprintf("failed to validate path (%s): %v", sdkmanagerPath, err))
 			continue
 		} else if !exists {


### PR DESCRIPTION
## Summary
- Swap `github.com/bitrise-io/go-utils/pathutil` → `github.com/bitrise-io/go-utils/v2/pathutil` in `sdk/sdk.go`.
- `IsPathExists` / `IsDirExists` live on `PathChecker` in v2; inline `pathutil.NewPathChecker().IsXxx(...)` at each call site (3) — keeps `New()` / `NewDefaultModel()` signatures stable.
- Test file (`sdk_test.go`) still on v1 `pathutil.NormalizedOSTempDirPath` — out of subtask scope.

Jira: [STEP-2479](https://bitrise.atlassian.net/browse/STEP-2479) (parent [STEP-2380](https://bitrise.atlassian.net/browse/STEP-2380))

## Test plan
- [x] `go build ./...`
- [x] `go test ./sdk/...`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[STEP-2479]: https://bitrise.atlassian.net/browse/STEP-2479?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[STEP-2380]: https://bitrise.atlassian.net/browse/STEP-2380?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ