### PR TITLE
chore: migrate sdkmanager pathutil v1 to v2

### DIFF
--- a/sdkmanager/sdkmanager.go
+++ b/sdkmanager/sdkmanager.go
@@ -7,8 +7,8 @@ import (
 
 	"github.com/bitrise-io/go-android/v2/sdk"
 	"github.com/bitrise-io/go-android/v2/sdkcomponent"
-	"github.com/bitrise-io/go-utils/pathutil"
 	"github.com/bitrise-io/go-utils/v2/command"
+	"github.com/bitrise-io/go-utils/v2/pathutil"
 )
 
 // Model ...
@@ -27,7 +27,7 @@ func New(sdk sdk.AndroidSdkInterface, cmdFactory command.Factory) (*Model, error
 	}
 
 	sdkmanagerPath := filepath.Join(cmdlineToolsPath, "sdkmanager")
-	if exist, err := pathutil.IsPathExists(sdkmanagerPath); err != nil {
+	if exist, err := pathutil.NewPathChecker().IsPathExists(sdkmanagerPath); err != nil {
 		return nil, err
 	} else if exist {
 		return &Model{
@@ -38,7 +38,7 @@ func New(sdk sdk.AndroidSdkInterface, cmdFactory command.Factory) (*Model, error
 	}
 
 	legacySdkmanagerPath := filepath.Join(cmdlineToolsPath, "android")
-	if exist, err := pathutil.IsPathExists(legacySdkmanagerPath); err != nil {
+	if exist, err := pathutil.NewPathChecker().IsPathExists(legacySdkmanagerPath); err != nil {
 		return nil, err
 	} else if exist {
 		return &Model{
@@ -66,7 +66,7 @@ func (model Model) IsInstalled(component sdkcomponent.Model) (bool, error) {
 	if indicatorFile != "" {
 		installPth = filepath.Join(installPth, indicatorFile)
 	}
-	return pathutil.IsPathExists(installPth)
+	return pathutil.NewPathChecker().IsPathExists(installPth)
 }
 
 // InstallCommand ...


### PR DESCRIPTION
## Summary
- Swap `github.com/bitrise-io/go-utils/pathutil` → `github.com/bitrise-io/go-utils/v2/pathutil` in `sdkmanager/sdkmanager.go`.
- 3 call sites → inline `pathutil.NewPathChecker().IsPathExists(...)`; keeps `New()` and `IsInstalled` signatures stable.

Jira: [STEP-2480](https://bitrise.atlassian.net/browse/STEP-2480) (parent [STEP-2380](https://bitrise.atlassian.net/browse/STEP-2380))

## Test plan
- [x] `go build ./...`
- [x] `go test ./sdkmanager/...`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[STEP-2480]: https://bitrise.atlassian.net/browse/STEP-2480?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[STEP-2380]: https://bitrise.atlassian.net/browse/STEP-2380?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ