### PR TITLE
chore: migrate androidsignature command v1 to v2

### DIFF
--- a/metaparser/androidsignature/signature.go
+++ b/metaparser/androidsignature/signature.go
@@ -9,8 +9,11 @@ import (
 	"strings"
 
 	"github.com/bitrise-io/go-android/v2/sdk"
-	"github.com/bitrise-io/go-utils/command"
+	"github.com/bitrise-io/go-utils/v2/command"
+	"github.com/bitrise-io/go-utils/v2/env"
 )
+
+var cmdFactory = command.NewFactory(env.NewRepository())
 
 const (
 	unsignedJarSignatureMessage = "jar is unsigned"
@@ -92,7 +95,7 @@ func getV2PlusSignature(pathParams []string) (string, error) {
 	}
 
 	params := append([]string{"verify", "--print-certs", "-v"}, pathParams...)
-	apkSignerOutput, err := command.New(apkSignerPath, params...).RunAndReturnTrimmedCombinedOutput()
+	apkSignerOutput, err := cmdFactory.Create(apkSignerPath, params, nil).RunAndReturnTrimmedCombinedOutput()
 	if err != nil {
 		var exitErr *exec.ExitError
 		if errors.As(err, &exitErr) {
@@ -123,7 +126,7 @@ func getV2PlusSignature(pathParams []string) (string, error) {
 
 func getJarSignature(path string) (string, error) {
 	params := []string{"-verify", "-certs", "-verbose", path}
-	output, err := command.New("jarsigner", params...).RunAndReturnTrimmedCombinedOutput()
+	output, err := cmdFactory.Create("jarsigner", params, nil).RunAndReturnTrimmedCombinedOutput()
 	if err != nil {
 		return "", err
 	}


### PR DESCRIPTION
## Summary
- Swap `github.com/bitrise-io/go-utils/command` → `github.com/bitrise-io/go-utils/v2/command` in `metaparser/androidsignature/signature.go`.
- v2 uses factory pattern; introduce package-level `cmdFactory = command.NewFactory(env.NewRepository())` so 2 package-level functions (`getV2PlusSignature`, `getJarSignature`) can call `Create(...)` without an API change.
- Test file (`signature_test.go`) still on v1 `command/git` — out of subtask scope.

Jira: [STEP-2482](https://bitrise.atlassian.net/browse/STEP-2482) (parent [STEP-2380](https://bitrise.atlassian.net/browse/STEP-2380))

## Test plan
- [x] `go build ./...`
- [x] `go test ./metaparser/androidsignature/...` — pre-existing env-dependent failures (`ANDROID_HOME` required) unchanged before/after this patch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[STEP-2482]: https://bitrise.atlassian.net/browse/STEP-2482?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[STEP-2380]: https://bitrise.atlassian.net/browse/STEP-2380?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ