### PR TITLE
feat: SSW-3065 add variant-keyed gradle/artifactmap package

### DIFF
--- a/gradle/artifactmap/artifactmap.go
+++ b/gradle/artifactmap/artifactmap.go
@@ -24,15 +24,17 @@ import (
 	"os"
 	"path/filepath"
 	"sort"
+	"strings"
 )
 
 // Version is the schema version this package reads and writes.
 const Version = 1
 
 // DefaultFileName is the conventional name of the map file inside the deploy
-// directory. Producers overwrite any existing file at this name (the map is
-// regenerated authoritative metadata); consumers should use the exported path
-// rather than assuming the name.
+// directory. A producer finding an existing map at this name Merges its own
+// entries into it (several build steps in one workflow accumulate a single
+// document); an unreadable existing file is replaced. Consumers should use
+// the exported path rather than assuming the name.
 const DefaultFileName = "android-artifact-map.json"
 
 // EnvKey is the environment variable producers export the map file's path in
@@ -154,28 +156,190 @@ func Build(apks, aabs, mappings []File) (Map, []string) {
 		g.mappingIsCanonical = canonical
 	}
 
-	// Key by variant name; disambiguate as module/variant only on collision.
-	nameCount := map[string]int{}
+	entries := make([]keyedEntry, 0, len(ordered))
 	for _, g := range ordered {
-		nameCount[g.variant.Variant]++
-	}
-	variants := map[string]Entry{}
-	for _, g := range ordered {
-		key := g.variant.Variant
-		if nameCount[g.variant.Variant] > 1 {
-			key = g.variant.Module + "/" + g.variant.Variant
-		}
-		// The producers discover files in filesystem-walk order, which is not a
-		// meaningful contract; sort so the document is deterministic.
-		sort.Strings(g.entry.APK)
-		sort.Strings(g.entry.AAB)
-		variants[key] = g.entry
+		entries = append(entries, keyedEntry{variant: g.variant, entry: g.entry})
 	}
 	sort.Strings(unmatched.APK)
 	sort.Strings(unmatched.AAB)
 	sort.Strings(unmatched.Mapping)
 
-	return Map{Version: Version, Variants: variants, Unmatched: unmatched}, warnings
+	return Map{Version: Version, Variants: keyEntries(entries), Unmatched: unmatched}, warnings
+}
+
+// keyedEntry pairs an entry with the variant identity its key derives from.
+type keyedEntry struct {
+	variant ArtifactVariant
+	entry   Entry
+}
+
+// keyEntries builds the Variants map: keys are variant names, disambiguated as
+// module/variant only on collision. Entry file lists are sorted — producers
+// discover files in filesystem-walk order, which is not a meaningful contract.
+func keyEntries(entries []keyedEntry) map[string]Entry {
+	nameCount := map[string]int{}
+	for _, e := range entries {
+		nameCount[e.variant.Variant]++
+	}
+	variants := map[string]Entry{}
+	for _, e := range entries {
+		key := e.variant.Variant
+		if nameCount[e.variant.Variant] > 1 {
+			key = e.variant.Module + "/" + e.variant.Variant
+		}
+		sort.Strings(e.entry.APK)
+		sort.Strings(e.entry.AAB)
+		variants[key] = e.entry
+	}
+	return variants
+}
+
+// variantFromKey reconstructs the variant identity a Variants key encodes:
+// keys are either the bare variant name or module/variant when modules
+// collided, and the entry always carries the module.
+func variantFromKey(key string, entry Entry) ArtifactVariant {
+	if entry.Module != "" && strings.HasPrefix(key, entry.Module+"/") {
+		return ArtifactVariant{Module: entry.Module, Variant: key[len(entry.Module)+1:]}
+	}
+	return ArtifactVariant{Module: entry.Module, Variant: key}
+}
+
+// Merge combines the map written by an earlier step run (base) with the map of
+// the current run (overlay), so several producer steps in one workflow
+// accumulate a single document instead of the last one overwriting the rest.
+// Entries are matched by (module, variant) and merged field-wise: a field the
+// overlay produced replaces the base's (a rebuild — reported in warnings when
+// the values differ), fields the overlay didn't produce keep the base's. An
+// apk-building run and an aab-building run of the same variant therefore
+// accumulate one complete entry. Unmatched lists are unioned and deduped.
+func Merge(base, overlay Map) (Map, []string) {
+	var warnings []string
+
+	combined := map[ArtifactVariant]Entry{}
+	var order []ArtifactVariant
+	for _, key := range base.SortedVariantKeys() {
+		entry := base.Variants[key]
+		variant := variantFromKey(key, entry)
+		combined[variant] = entry
+		order = append(order, variant)
+	}
+	for _, key := range overlay.SortedVariantKeys() {
+		entry := overlay.Variants[key]
+		variant := variantFromKey(key, entry)
+		baseEntry, exists := combined[variant]
+		if !exists {
+			combined[variant] = entry
+			order = append(order, variant)
+			continue
+		}
+		merged, mergeWarnings := mergeEntries(baseEntry, entry, variant.Variant)
+		warnings = append(warnings, mergeWarnings...)
+		combined[variant] = merged
+	}
+
+	entries := make([]keyedEntry, 0, len(order))
+	for _, variant := range order {
+		entries = append(entries, keyedEntry{variant: variant, entry: combined[variant]})
+	}
+
+	unmatched := Unmatched{
+		APK:     unionSorted(base.Unmatched.APK, overlay.Unmatched.APK),
+		AAB:     unionSorted(base.Unmatched.AAB, overlay.Unmatched.AAB),
+		Mapping: unionSorted(base.Unmatched.Mapping, overlay.Unmatched.Mapping),
+	}
+
+	return Map{Version: Version, Variants: keyEntries(entries), Unmatched: unmatched}, warnings
+}
+
+// mergeEntries combines one variant's base and overlay entries field-wise:
+// what the overlay produced wins, what it didn't produce survives from the
+// base. Replacing a differing earlier value is reported.
+func mergeEntries(base, overlay Entry, variantName string) (Entry, []string) {
+	var warnings []string
+	merged := overlay
+	if merged.Module == "" {
+		merged.Module = base.Module
+	}
+
+	if len(overlay.APK) == 0 {
+		merged.APK = base.APK
+	} else if len(base.APK) != 0 && !stringSlicesEqual(base.APK, overlay.APK) {
+		warnings = append(warnings, fmt.Sprintf(
+			"variant %s: a later step rebuilt its APKs, the artifact map now references the newer files", variantName))
+	}
+
+	if len(overlay.AAB) == 0 {
+		merged.AAB = base.AAB
+	} else if len(base.AAB) != 0 && !stringSlicesEqual(base.AAB, overlay.AAB) {
+		warnings = append(warnings, fmt.Sprintf(
+			"variant %s: a later step rebuilt its AABs, the artifact map now references the newer files", variantName))
+	}
+
+	if overlay.Mapping == "" {
+		merged.Mapping = base.Mapping
+	} else if base.Mapping != "" && base.Mapping != overlay.Mapping {
+		warnings = append(warnings, fmt.Sprintf(
+			"variant %s: a later step rebuilt its mapping file, the artifact map now references %s instead of %s",
+			variantName, overlay.Mapping, base.Mapping))
+	}
+
+	return merged, warnings
+}
+
+func stringSlicesEqual(a, b []string) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for i := range a {
+		if a[i] != b[i] {
+			return false
+		}
+	}
+	return true
+}
+
+func unionSorted(a, b []string) []string {
+	seen := map[string]bool{}
+	union := []string{}
+	for _, list := range [][]string{a, b} {
+		for _, name := range list {
+			if !seen[name] {
+				seen[name] = true
+				union = append(union, name)
+			}
+		}
+	}
+	sort.Strings(union)
+	return union
+}
+
+// ReplaceFile renames a file reference wherever it appears — the variants'
+// APK/AAB lists and the unmatched lists — and reports whether anything was
+// replaced. A step that transforms an artifact in the deploy dir under a new
+// name (e.g. signing) uses it to keep the map pointing at the current file.
+// Mapping references are left alone: artifact transforms don't touch them.
+func (m *Map) ReplaceFile(oldName, newName string) bool {
+	replaced := false
+	replaceIn := func(list []string) {
+		changed := false
+		for i, name := range list {
+			if name == oldName {
+				list[i] = newName
+				changed = true
+			}
+		}
+		if changed {
+			sort.Strings(list)
+			replaced = true
+		}
+	}
+	for _, entry := range m.Variants {
+		replaceIn(entry.APK)
+		replaceIn(entry.AAB)
+	}
+	replaceIn(m.Unmatched.APK)
+	replaceIn(m.Unmatched.AAB)
+	return replaced
 }
 
 // IsEmpty reports whether the map carries no artifacts at all — producers can
@@ -206,14 +370,24 @@ func Resolve(mapPath, name string) string {
 	return filepath.Join(filepath.Dir(mapPath), name)
 }
 
+// Marshal renders the document exactly as Write persists it — indented, with
+// a trailing newline — so steps can also print it to the build log.
+func Marshal(m Map) ([]byte, error) {
+	data, err := json.MarshalIndent(m, "", "  ")
+	if err != nil {
+		return nil, fmt.Errorf("marshal artifact map: %w", err)
+	}
+	return append(data, '\n'), nil
+}
+
 // Write marshals the map and writes it to path. The document is indented so
 // the exported build artifact stays human-readable.
 func Write(path string, m Map) error {
-	data, err := json.MarshalIndent(m, "", "  ")
+	data, err := Marshal(m)
 	if err != nil {
-		return fmt.Errorf("marshal artifact map: %w", err)
+		return err
 	}
-	if err := os.WriteFile(path, append(data, '\n'), 0644); err != nil {
+	if err := os.WriteFile(path, data, 0644); err != nil {
 		return fmt.Errorf("write artifact map: %w", err)
 	}
 	return nil

--- a/gradle/artifactmap/artifactmap.go
+++ b/gradle/artifactmap/artifactmap.go
@@ -1,36 +1,21 @@
-// Package artifactmap defines the variant-keyed Android artifact map that the
-// Android build steps (gradle-runner, android-build) export and the Google
-// Play Deploy step consumes.
+// Package artifactmap defines the variant-keyed artifact map that the Android
+// build steps export and the Google Play Deploy step consumes: which exported
+// APK/AAB and which mapping.txt belong to the same build variant — something
+// the flat BITRISE_*_PATH outputs cannot express, while Google Play accepts
+// exactly one mapping per version code.
 //
-// The map answers the question the flat BITRISE_*_PATH outputs cannot: which
-// exported APK/AAB and which mapping.txt belong to the same build variant. A
-// multi-variant build produces one mapping file per variant, and Google Play
-// accepts exactly one mapping per version code, so a consumer must be able to
-// pair them by identity instead of guessing by export order.
-//
-// The map is written as a JSON file into the Bitrise deploy directory, next to
-// the exported artifacts, and its path is exported as
-// BITRISE_ANDROID_ARTIFACT_MAP_PATH. All file references inside the map are
-// bare file names relative to the map file's own directory, so the map stays
-// valid when the deploy directory is archived or moved. Use Resolve to turn an
-// entry's file name into a full path.
-//
-// The package intentionally depends only on the standard library so a consumer
-// step can vendor just this package without pulling in the rest of the gradle
-// helpers.
+// Producers write the map as JSON into the deploy directory and export its
+// path as BITRISE_ANDROID_ARTIFACT_MAP_PATH. File references are bare names
+// relative to the map file's directory (see Resolve), so the map survives the
+// directory being archived or moved. The package is stdlib-only so consumers
+// can vendor it alone.
 //
 // # Schema evolution
 //
-// Producers and consumers of the map are separate steps, version-pinned
-// independently in user workflows, so the schema must stay compatible across
-// mixed versions. The rules:
-//
-//   - Additive changes (new fields) keep the version number. Consumers ignore
-//     unknown JSON fields (encoding/json's default), so an older consumer
-//     paired with a newer producer keeps working on the fields it knows.
-//   - The version number bumps ONLY on breaking layout changes, which should
-//     be avoided; Read rejects documents with a newer version than it
-//     understands rather than mis-reading them.
+// Producers and consumers are version-pinned independently in user workflows.
+// Additive fields keep the version number (unknown JSON fields are ignored);
+// the version bumps only on breaking layout changes, and Read rejects
+// documents newer than it understands.
 package artifactmap
 
 import (
@@ -45,48 +30,37 @@ import (
 const Version = 1
 
 // DefaultFileName is the conventional name of the map file inside the deploy
-// directory. The map is regenerated authoritative metadata: producers
-// OVERWRITE any existing file at this name instead of writing a renamed copy
-// next to it. Consumers should still use the exported path rather than
-// assuming the name.
+// directory. Producers overwrite any existing file at this name (the map is
+// regenerated authoritative metadata); consumers should use the exported path
+// rather than assuming the name.
 const DefaultFileName = "android-artifact-map.json"
 
-// EnvKey is the environment variable the producing steps export the map file's
-// path in, and the consuming steps read it from by default.
+// EnvKey is the environment variable producers export the map file's path in
+// and consumers read it from by default.
 const EnvKey = "BITRISE_ANDROID_ARTIFACT_MAP_PATH"
 
-// Map is the top-level document: the artifacts of one build, grouped by
-// variant.
+// Map is the top-level document: one build's artifacts, grouped by variant.
 type Map struct {
-	// Version identifies the schema so future readers can detect
-	// incompatible documents.
 	Version int `json:"version"`
-	// Variants is keyed by the merged Gradle variant name (for example
-	// "demoRelease"). When two modules produce the same variant name, the
-	// colliding keys are disambiguated as "module/variant". Consumers must
-	// treat the key as informational and pair artifacts by file identity.
+	// Variants is keyed by the merged Gradle variant name ("demoRelease");
+	// colliding names across modules are disambiguated as "module/variant".
+	// The key is informational — consumers pair artifacts by file identity.
 	Variants map[string]Entry `json:"variants"`
-	// Unmatched lists exported files whose variant could not be derived
-	// from their build-output path (for example artifacts written to
-	// non-standard locations). They are preserved so no export is silently
-	// unaccounted for.
+	// Unmatched lists exported files whose variant could not be derived from
+	// their build-output path, so no export goes silently unaccounted for.
 	Unmatched Unmatched `json:"unmatched"`
 }
 
-// Entry groups the exported files of a single build variant. All file
-// references are names relative to the map file's directory.
+// Entry groups one variant's exported files, as names relative to the map
+// file's directory.
 type Entry struct {
-	// Module is the Gradle module the variant belongs to (for example
-	// "app"). Empty when it could not be derived.
+	// Module is the Gradle module ("app"); empty when it could not be derived.
 	Module string `json:"module"`
-	// Mapping is the R8/ProGuard mapping file of the variant, empty when
-	// the variant produced none. A variant has at most one mapping file,
-	// mirroring Google Play's one-mapping-per-version-code model.
+	// Mapping is the variant's R8/ProGuard mapping file; empty when none.
 	Mapping string `json:"mapping,omitempty"`
-	// AAB lists the app bundles of the variant (in practice at most one).
+	// AAB lists the variant's app bundles (in practice at most one).
 	AAB []string `json:"aab"`
-	// APK lists the APKs of the variant; ABI/density splits make several
-	// per variant legitimate.
+	// APK lists the variant's APKs (several with ABI/density splits).
 	APK []string `json:"apk"`
 }
 
@@ -97,29 +71,27 @@ type Unmatched struct {
 	Mapping []string `json:"mapping"`
 }
 
-// File pairs a file's location in the deploy directory with the build-output
-// path it was copied from. DeployPath is what ends up referenced in the map
-// (as its base name); SourcePath is what the variant is derived from, because
-// the deploy directory is flat while the Gradle output tree encodes the
-// variant.
+// File pairs a file's deploy-dir location with the build-output path it was
+// copied from: the map references DeployPath's base name, while the variant is
+// derived from SourcePath (the deploy dir is flat; only the Gradle output tree
+// encodes the variant).
 type File struct {
 	DeployPath string
 	SourcePath string
 }
 
 // Build assembles a Map from the files a step exported. Variants are derived
-// from each file's SourcePath; files with unrecognisable paths are collected
-// under Unmatched. When several mapping files resolve to the same variant the
-// last one wins and the case is reported in warnings (one message per
-// overwritten file); warnings is empty on a clean build.
+// from each file's SourcePath; unrecognisable paths land under Unmatched.
+// When several mapping files resolve to the same variant, a file literally
+// named mapping.txt wins, otherwise the last one; every dropped file is
+// reported in warnings.
 func Build(apks, aabs, mappings []File) (Map, []string) {
 	type group struct {
 		variant ArtifactVariant
 		entry   Entry
-		// mappingIsCanonical marks that the current mapping came from a
-		// source file literally named mapping.txt — the shrinker's real
-		// output — which must not be displaced by sibling report files
-		// (usage.txt, seeds.txt, ...) matched by a widened filter.
+		// the current mapping is a file literally named mapping.txt (the
+		// shrinker's real output) and must not be displaced by sibling
+		// report files (usage.txt, seeds.txt, ...) matched by a wide filter
 		mappingIsCanonical bool
 	}
 	groups := map[ArtifactVariant]*group{}
@@ -224,10 +196,9 @@ func (m Map) SortedVariantKeys() []string {
 	return keys
 }
 
-// Resolve turns a file name referenced by the map into a full path, resolving
-// it against the directory of the map file itself (file names in the map are
-// relative to it). mapPath is the path the map was read from; name is an
-// Entry/Unmatched value. An empty name resolves to "".
+// Resolve turns a file name referenced by the map (an Entry/Unmatched value)
+// into a full path against the map file's own directory. An empty name
+// resolves to "".
 func Resolve(mapPath, name string) string {
 	if name == "" {
 		return ""

--- a/gradle/artifactmap/artifactmap.go
+++ b/gradle/artifactmap/artifactmap.go
@@ -18,6 +18,19 @@
 // The package intentionally depends only on the standard library so a consumer
 // step can vendor just this package without pulling in the rest of the gradle
 // helpers.
+//
+// # Schema evolution
+//
+// Producers and consumers of the map are separate steps, version-pinned
+// independently in user workflows, so the schema must stay compatible across
+// mixed versions. The rules:
+//
+//   - Additive changes (new fields) keep the version number. Consumers ignore
+//     unknown JSON fields (encoding/json's default), so an older consumer
+//     paired with a newer producer keeps working on the fields it knows.
+//   - The version number bumps ONLY on breaking layout changes, which should
+//     be avoided; Read rejects documents with a newer version than it
+//     understands rather than mis-reading them.
 package artifactmap
 
 import (
@@ -32,8 +45,10 @@ import (
 const Version = 1
 
 // DefaultFileName is the conventional name of the map file inside the deploy
-// directory. Producers may deviate (e.g. on name collision), consumers must
-// not rely on it and should use the exported path instead.
+// directory. The map is regenerated authoritative metadata: producers
+// OVERWRITE any existing file at this name instead of writing a renamed copy
+// next to it. Consumers should still use the exported path rather than
+// assuming the name.
 const DefaultFileName = "android-artifact-map.json"
 
 // EnvKey is the environment variable the producing steps export the map file's
@@ -101,6 +116,11 @@ func Build(apks, aabs, mappings []File) (Map, []string) {
 	type group struct {
 		variant ArtifactVariant
 		entry   Entry
+		// mappingIsCanonical marks that the current mapping came from a
+		// source file literally named mapping.txt — the shrinker's real
+		// output — which must not be displaced by sibling report files
+		// (usage.txt, seeds.txt, ...) matched by a widened filter.
+		mappingIsCanonical bool
 	}
 	groups := map[ArtifactVariant]*group{}
 	ordered := []*group{} // deterministic iteration for key assignment
@@ -142,12 +162,24 @@ func Build(apks, aabs, mappings []File) (Map, []string) {
 			continue
 		}
 		name := filepath.Base(f.DeployPath)
-		if g.entry.Mapping != "" && g.entry.Mapping != name {
+		canonical := filepath.Base(f.SourcePath) == "mapping.txt"
+		switch {
+		case g.entry.Mapping == "" || g.entry.Mapping == name:
+			// first mapping for the variant (or a re-listing of the same file)
+		case g.mappingIsCanonical && !canonical:
+			// never displace the shrinker's real mapping.txt with a sibling
+			// report file that a widened filter also matched
+			warnings = append(warnings, fmt.Sprintf(
+				"variant %s matched several mapping files: keeping %s (named mapping.txt), dropping %s",
+				g.variant.Variant, g.entry.Mapping, name))
+			continue
+		default:
 			warnings = append(warnings, fmt.Sprintf(
 				"variant %s matched several mapping files: keeping %s, dropping %s",
 				g.variant.Variant, name, g.entry.Mapping))
 		}
 		g.entry.Mapping = name
+		g.mappingIsCanonical = canonical
 	}
 
 	// Key by variant name; disambiguate as module/variant only on collision.

--- a/gradle/artifactmap/artifactmap.go
+++ b/gradle/artifactmap/artifactmap.go
@@ -1,0 +1,238 @@
+// Package artifactmap defines the variant-keyed Android artifact map that the
+// Android build steps (gradle-runner, android-build) export and the Google
+// Play Deploy step consumes.
+//
+// The map answers the question the flat BITRISE_*_PATH outputs cannot: which
+// exported APK/AAB and which mapping.txt belong to the same build variant. A
+// multi-variant build produces one mapping file per variant, and Google Play
+// accepts exactly one mapping per version code, so a consumer must be able to
+// pair them by identity instead of guessing by export order.
+//
+// The map is written as a JSON file into the Bitrise deploy directory, next to
+// the exported artifacts, and its path is exported as
+// BITRISE_ANDROID_ARTIFACT_MAP_PATH. All file references inside the map are
+// bare file names relative to the map file's own directory, so the map stays
+// valid when the deploy directory is archived or moved. Use Resolve to turn an
+// entry's file name into a full path.
+//
+// The package intentionally depends only on the standard library so a consumer
+// step can vendor just this package without pulling in the rest of the gradle
+// helpers.
+package artifactmap
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"sort"
+)
+
+// Version is the schema version this package reads and writes.
+const Version = 1
+
+// DefaultFileName is the conventional name of the map file inside the deploy
+// directory. Producers may deviate (e.g. on name collision), consumers must
+// not rely on it and should use the exported path instead.
+const DefaultFileName = "android-artifact-map.json"
+
+// EnvKey is the environment variable the producing steps export the map file's
+// path in, and the consuming steps read it from by default.
+const EnvKey = "BITRISE_ANDROID_ARTIFACT_MAP_PATH"
+
+// Map is the top-level document: the artifacts of one build, grouped by
+// variant.
+type Map struct {
+	// Version identifies the schema so future readers can detect
+	// incompatible documents.
+	Version int `json:"version"`
+	// Variants is keyed by the merged Gradle variant name (for example
+	// "demoRelease"). When two modules produce the same variant name, the
+	// colliding keys are disambiguated as "module/variant". Consumers must
+	// treat the key as informational and pair artifacts by file identity.
+	Variants map[string]Entry `json:"variants"`
+	// Unmatched lists exported files whose variant could not be derived
+	// from their build-output path (for example artifacts written to
+	// non-standard locations). They are preserved so no export is silently
+	// unaccounted for.
+	Unmatched Unmatched `json:"unmatched"`
+}
+
+// Entry groups the exported files of a single build variant. All file
+// references are names relative to the map file's directory.
+type Entry struct {
+	// Module is the Gradle module the variant belongs to (for example
+	// "app"). Empty when it could not be derived.
+	Module string `json:"module"`
+	// Mapping is the R8/ProGuard mapping file of the variant, empty when
+	// the variant produced none. A variant has at most one mapping file,
+	// mirroring Google Play's one-mapping-per-version-code model.
+	Mapping string `json:"mapping,omitempty"`
+	// AAB lists the app bundles of the variant (in practice at most one).
+	AAB []string `json:"aab"`
+	// APK lists the APKs of the variant; ABI/density splits make several
+	// per variant legitimate.
+	APK []string `json:"apk"`
+}
+
+// Unmatched lists exported files that could not be attributed to a variant.
+type Unmatched struct {
+	APK     []string `json:"apk"`
+	AAB     []string `json:"aab"`
+	Mapping []string `json:"mapping"`
+}
+
+// File pairs a file's location in the deploy directory with the build-output
+// path it was copied from. DeployPath is what ends up referenced in the map
+// (as its base name); SourcePath is what the variant is derived from, because
+// the deploy directory is flat while the Gradle output tree encodes the
+// variant.
+type File struct {
+	DeployPath string
+	SourcePath string
+}
+
+// Build assembles a Map from the files a step exported. Variants are derived
+// from each file's SourcePath; files with unrecognisable paths are collected
+// under Unmatched. When several mapping files resolve to the same variant the
+// last one wins and the case is reported in warnings (one message per
+// overwritten file); warnings is empty on a clean build.
+func Build(apks, aabs, mappings []File) (Map, []string) {
+	type group struct {
+		variant ArtifactVariant
+		entry   Entry
+	}
+	groups := map[ArtifactVariant]*group{}
+	ordered := []*group{} // deterministic iteration for key assignment
+	var warnings []string
+
+	grab := func(f File) (*group, bool) {
+		variant, ok := VariantFromPath(f.SourcePath)
+		if !ok {
+			return nil, false
+		}
+		g, ok := groups[variant]
+		if !ok {
+			g = &group{variant: variant, entry: Entry{Module: variant.Module, AAB: []string{}, APK: []string{}}}
+			groups[variant] = g
+			ordered = append(ordered, g)
+		}
+		return g, true
+	}
+
+	unmatched := Unmatched{APK: []string{}, AAB: []string{}, Mapping: []string{}}
+	for _, f := range apks {
+		if g, ok := grab(f); ok {
+			g.entry.APK = append(g.entry.APK, filepath.Base(f.DeployPath))
+		} else {
+			unmatched.APK = append(unmatched.APK, filepath.Base(f.DeployPath))
+		}
+	}
+	for _, f := range aabs {
+		if g, ok := grab(f); ok {
+			g.entry.AAB = append(g.entry.AAB, filepath.Base(f.DeployPath))
+		} else {
+			unmatched.AAB = append(unmatched.AAB, filepath.Base(f.DeployPath))
+		}
+	}
+	for _, f := range mappings {
+		g, ok := grab(f)
+		if !ok {
+			unmatched.Mapping = append(unmatched.Mapping, filepath.Base(f.DeployPath))
+			continue
+		}
+		name := filepath.Base(f.DeployPath)
+		if g.entry.Mapping != "" && g.entry.Mapping != name {
+			warnings = append(warnings, fmt.Sprintf(
+				"variant %s matched several mapping files: keeping %s, dropping %s",
+				g.variant.Variant, name, g.entry.Mapping))
+		}
+		g.entry.Mapping = name
+	}
+
+	// Key by variant name; disambiguate as module/variant only on collision.
+	nameCount := map[string]int{}
+	for _, g := range ordered {
+		nameCount[g.variant.Variant]++
+	}
+	variants := map[string]Entry{}
+	for _, g := range ordered {
+		key := g.variant.Variant
+		if nameCount[g.variant.Variant] > 1 {
+			key = g.variant.Module + "/" + g.variant.Variant
+		}
+		// The producers discover files in filesystem-walk order, which is not a
+		// meaningful contract; sort so the document is deterministic.
+		sort.Strings(g.entry.APK)
+		sort.Strings(g.entry.AAB)
+		variants[key] = g.entry
+	}
+	sort.Strings(unmatched.APK)
+	sort.Strings(unmatched.AAB)
+	sort.Strings(unmatched.Mapping)
+
+	return Map{Version: Version, Variants: variants, Unmatched: unmatched}, warnings
+}
+
+// IsEmpty reports whether the map carries no artifacts at all — producers can
+// skip writing a file for such a build.
+func (m Map) IsEmpty() bool {
+	return len(m.Variants) == 0 &&
+		len(m.Unmatched.APK) == 0 && len(m.Unmatched.AAB) == 0 && len(m.Unmatched.Mapping) == 0
+}
+
+// SortedVariantKeys returns the variant keys in lexical order, for
+// deterministic logging and iteration.
+func (m Map) SortedVariantKeys() []string {
+	keys := make([]string, 0, len(m.Variants))
+	for key := range m.Variants {
+		keys = append(keys, key)
+	}
+	sort.Strings(keys)
+	return keys
+}
+
+// Resolve turns a file name referenced by the map into a full path, resolving
+// it against the directory of the map file itself (file names in the map are
+// relative to it). mapPath is the path the map was read from; name is an
+// Entry/Unmatched value. An empty name resolves to "".
+func Resolve(mapPath, name string) string {
+	if name == "" {
+		return ""
+	}
+	return filepath.Join(filepath.Dir(mapPath), name)
+}
+
+// Write marshals the map and writes it to path. The document is indented so
+// the exported build artifact stays human-readable.
+func Write(path string, m Map) error {
+	data, err := json.MarshalIndent(m, "", "  ")
+	if err != nil {
+		return fmt.Errorf("marshal artifact map: %w", err)
+	}
+	if err := os.WriteFile(path, append(data, '\n'), 0644); err != nil {
+		return fmt.Errorf("write artifact map: %w", err)
+	}
+	return nil
+}
+
+// Read loads and validates a map written by Write. It rejects documents with a
+// newer schema version than this package understands, and documents that are
+// not artifact maps at all (missing version).
+func Read(path string) (Map, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return Map{}, fmt.Errorf("read artifact map: %w", err)
+	}
+	var m Map
+	if err := json.Unmarshal(data, &m); err != nil {
+		return Map{}, fmt.Errorf("parse artifact map %s: %w", path, err)
+	}
+	if m.Version == 0 {
+		return Map{}, fmt.Errorf("parse artifact map %s: missing schema version, not an artifact map", path)
+	}
+	if m.Version > Version {
+		return Map{}, fmt.Errorf("artifact map %s has schema version %d, this consumer understands up to %d", path, m.Version, Version)
+	}
+	return m, nil
+}

--- a/gradle/artifactmap/artifactmap_test.go
+++ b/gradle/artifactmap/artifactmap_test.go
@@ -1,0 +1,232 @@
+package artifactmap
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"reflect"
+	"testing"
+)
+
+const (
+	demoAPKSource       = "/bitrise/src/app/build/outputs/apk/demo/release/app-demo-release.apk"
+	demoSplitAPKSource  = "/bitrise/src/app/build/outputs/apk/demo/release/app-demo-arm64-v8a-release.apk"
+	demoAABSource       = "/bitrise/src/app/build/outputs/bundle/demoRelease/app-demo-release.aab"
+	demoMappingSource   = "/bitrise/src/app/build/outputs/mapping/demoRelease/mapping.txt"
+	paidAPKSource       = "/bitrise/src/app/build/outputs/apk/paid/release/app-paid-release.apk"
+	paidMappingSource   = "/bitrise/src/app/build/outputs/mapping/paidRelease/mapping.txt"
+	strayMappingSource  = "/bitrise/src/app/custom-out/mapping.txt"
+	wearAPKSource       = "/bitrise/src/wear/build/outputs/apk/demo/release/wear-demo-release.apk"
+	wearMappingSource   = "/bitrise/src/wear/build/outputs/mapping/demoRelease/mapping.txt"
+	deployDir           = "/bitrise/deploy"
+	demoMappingRenamed  = "/bitrise/deploy/mapping-20260805121530.txt"
+	otherMappingRenamed = "/bitrise/deploy/mapping-20260805121599.txt"
+)
+
+func deploy(name string) string { return filepath.Join(deployDir, name) }
+
+func TestBuild_GroupsByVariant(t *testing.T) {
+	m, warnings := Build(
+		[]File{
+			{DeployPath: deploy("app-demo-release.apk"), SourcePath: demoAPKSource},
+			{DeployPath: deploy("app-demo-arm64-v8a-release.apk"), SourcePath: demoSplitAPKSource},
+			{DeployPath: deploy("app-paid-release.apk"), SourcePath: paidAPKSource},
+		},
+		[]File{
+			{DeployPath: deploy("app-demo-release.aab"), SourcePath: demoAABSource},
+		},
+		[]File{
+			{DeployPath: deploy("mapping.txt"), SourcePath: demoMappingSource},
+			{DeployPath: demoMappingRenamed, SourcePath: paidMappingSource},
+		},
+	)
+
+	if len(warnings) != 0 {
+		t.Fatalf("unexpected warnings: %v", warnings)
+	}
+	want := map[string]Entry{
+		"demoRelease": {
+			Module:  "app",
+			Mapping: "mapping.txt",
+			AAB:     []string{"app-demo-release.aab"},
+			// names are sorted, not discovery-ordered
+			APK: []string{"app-demo-arm64-v8a-release.apk", "app-demo-release.apk"},
+		},
+		"paidRelease": {
+			Module:  "app",
+			Mapping: "mapping-20260805121530.txt",
+			AAB:     []string{},
+			APK:     []string{"app-paid-release.apk"},
+		},
+	}
+	if !reflect.DeepEqual(m.Variants, want) {
+		t.Fatalf("Variants = %+v, want %+v", m.Variants, want)
+	}
+	if m.Version != Version {
+		t.Fatalf("Version = %d, want %d", m.Version, Version)
+	}
+	if len(m.Unmatched.APK)+len(m.Unmatched.AAB)+len(m.Unmatched.Mapping) != 0 {
+		t.Fatalf("expected no unmatched files, got %+v", m.Unmatched)
+	}
+}
+
+func TestBuild_UnderivableVariantGoesToUnmatched(t *testing.T) {
+	m, warnings := Build(
+		nil,
+		nil,
+		[]File{{DeployPath: deploy("mapping.txt"), SourcePath: strayMappingSource}},
+	)
+
+	if len(warnings) != 0 {
+		t.Fatalf("unexpected warnings: %v", warnings)
+	}
+	if len(m.Variants) != 0 {
+		t.Fatalf("expected no variants, got %+v", m.Variants)
+	}
+	if want := []string{"mapping.txt"}; !reflect.DeepEqual(m.Unmatched.Mapping, want) {
+		t.Fatalf("Unmatched.Mapping = %v, want %v", m.Unmatched.Mapping, want)
+	}
+}
+
+func TestBuild_DuplicateMappingWarnsAndKeepsLast(t *testing.T) {
+	m, warnings := Build(
+		nil,
+		nil,
+		[]File{
+			{DeployPath: deploy("mapping.txt"), SourcePath: demoMappingSource},
+			{DeployPath: otherMappingRenamed, SourcePath: demoMappingSource},
+		},
+	)
+
+	if len(warnings) != 1 {
+		t.Fatalf("expected 1 warning, got %v", warnings)
+	}
+	if got := m.Variants["demoRelease"].Mapping; got != "mapping-20260805121599.txt" {
+		t.Fatalf("Mapping = %q, want the last one", got)
+	}
+}
+
+func TestBuild_SameVariantNameAcrossModulesGetsModulePrefixedKeys(t *testing.T) {
+	m, _ := Build(
+		[]File{
+			{DeployPath: deploy("app-demo-release.apk"), SourcePath: demoAPKSource},
+			{DeployPath: deploy("wear-demo-release.apk"), SourcePath: wearAPKSource},
+		},
+		nil,
+		[]File{
+			{DeployPath: deploy("mapping.txt"), SourcePath: demoMappingSource},
+			{DeployPath: demoMappingRenamed, SourcePath: wearMappingSource},
+		},
+	)
+
+	wantKeys := []string{"app/demoRelease", "wear/demoRelease"}
+	if got := m.SortedVariantKeys(); !reflect.DeepEqual(got, wantKeys) {
+		t.Fatalf("keys = %v, want %v", got, wantKeys)
+	}
+	if got := m.Variants["app/demoRelease"].Mapping; got != "mapping.txt" {
+		t.Fatalf("app mapping = %q, want mapping.txt", got)
+	}
+	if got := m.Variants["wear/demoRelease"].Mapping; got != "mapping-20260805121530.txt" {
+		t.Fatalf("wear mapping = %q, want the renamed file", got)
+	}
+}
+
+func TestBuild_EmptyInput(t *testing.T) {
+	m, warnings := Build(nil, nil, nil)
+	if len(warnings) != 0 {
+		t.Fatalf("unexpected warnings: %v", warnings)
+	}
+	if !m.IsEmpty() {
+		t.Fatalf("expected empty map, got %+v", m)
+	}
+}
+
+func TestWriteRead_RoundTrip(t *testing.T) {
+	m, _ := Build(
+		[]File{{DeployPath: deploy("app-demo-release.apk"), SourcePath: demoAPKSource}},
+		[]File{{DeployPath: deploy("app-demo-release.aab"), SourcePath: demoAABSource}},
+		[]File{{DeployPath: deploy("mapping.txt"), SourcePath: demoMappingSource}},
+	)
+
+	path := filepath.Join(t.TempDir(), DefaultFileName)
+	if err := Write(path, m); err != nil {
+		t.Fatalf("Write: %v", err)
+	}
+
+	got, err := Read(path)
+	if err != nil {
+		t.Fatalf("Read: %v", err)
+	}
+	if !reflect.DeepEqual(got, m) {
+		t.Fatalf("round-trip mismatch:\n got %+v\nwant %+v", got, m)
+	}
+}
+
+// TestWrite_DocumentShape locks the on-disk contract: this is what consumers
+// outside this module parse, so a change here is a schema version bump.
+func TestWrite_DocumentShape(t *testing.T) {
+	m, _ := Build(
+		[]File{{DeployPath: deploy("app-demo-release.apk"), SourcePath: demoAPKSource}},
+		[]File{{DeployPath: deploy("app-demo-release.aab"), SourcePath: demoAABSource}},
+		[]File{{DeployPath: deploy("mapping.txt"), SourcePath: demoMappingSource}},
+	)
+
+	path := filepath.Join(t.TempDir(), DefaultFileName)
+	if err := Write(path, m); err != nil {
+		t.Fatalf("Write: %v", err)
+	}
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read back: %v", err)
+	}
+
+	var doc map[string]any
+	if err := json.Unmarshal(data, &doc); err != nil {
+		t.Fatalf("written document is not valid JSON: %v", err)
+	}
+	want := map[string]any{
+		"version": float64(1),
+		"variants": map[string]any{
+			"demoRelease": map[string]any{
+				"module":  "app",
+				"mapping": "mapping.txt",
+				"aab":     []any{"app-demo-release.aab"},
+				"apk":     []any{"app-demo-release.apk"},
+			},
+		},
+		"unmatched": map[string]any{"apk": []any{}, "aab": []any{}, "mapping": []any{}},
+	}
+	if !reflect.DeepEqual(doc, want) {
+		t.Fatalf("document shape changed:\n got %#v\nwant %#v", doc, want)
+	}
+}
+
+func TestRead_RejectsNewerVersion(t *testing.T) {
+	path := filepath.Join(t.TempDir(), DefaultFileName)
+	if err := os.WriteFile(path, []byte(`{"version": 99, "variants": {}}`), 0644); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := Read(path); err == nil {
+		t.Fatal("expected error for newer schema version")
+	}
+}
+
+func TestRead_RejectsForeignJSON(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "something.json")
+	if err := os.WriteFile(path, []byte(`{"name": "not an artifact map"}`), 0644); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := Read(path); err == nil {
+		t.Fatal("expected error for JSON without schema version")
+	}
+}
+
+func TestResolve(t *testing.T) {
+	mapPath := "/bitrise/deploy/android-artifact-map.json"
+	if got, want := Resolve(mapPath, "mapping.txt"), "/bitrise/deploy/mapping.txt"; got != want {
+		t.Fatalf("Resolve = %q, want %q", got, want)
+	}
+	if got := Resolve(mapPath, ""); got != "" {
+		t.Fatalf("Resolve of empty name = %q, want empty", got)
+	}
+}

--- a/gradle/artifactmap/artifactmap_test.go
+++ b/gradle/artifactmap/artifactmap_test.go
@@ -88,6 +88,42 @@ func TestBuild_UnderivableVariantGoesToUnmatched(t *testing.T) {
 	}
 }
 
+// TestBuild_CanonicalMappingTxtWinsOverReportFiles: R8 writes usage.txt,
+// seeds.txt etc. next to mapping.txt; when a widened filter matches them too,
+// the file literally named mapping.txt must stay the variant's mapping no
+// matter the discovery order.
+func TestBuild_CanonicalMappingTxtWinsOverReportFiles(t *testing.T) {
+	demoMappingDir := "/bitrise/src/app/build/outputs/mapping/demoRelease/"
+	m, warnings := Build(
+		nil,
+		nil,
+		[]File{
+			{DeployPath: deploy("mapping.txt"), SourcePath: demoMappingDir + "mapping.txt"},
+			{DeployPath: deploy("usage.txt"), SourcePath: demoMappingDir + "usage.txt"},
+		},
+	)
+
+	if len(warnings) != 1 {
+		t.Fatalf("expected 1 warning about the dropped report file, got %v", warnings)
+	}
+	if got := m.Variants["demoRelease"].Mapping; got != "mapping.txt" {
+		t.Fatalf("Mapping = %q, want the canonical mapping.txt", got)
+	}
+
+	// same result when the report file is discovered first
+	m, _ = Build(
+		nil,
+		nil,
+		[]File{
+			{DeployPath: deploy("usage.txt"), SourcePath: demoMappingDir + "usage.txt"},
+			{DeployPath: deploy("mapping.txt"), SourcePath: demoMappingDir + "mapping.txt"},
+		},
+	)
+	if got := m.Variants["demoRelease"].Mapping; got != "mapping.txt" {
+		t.Fatalf("Mapping = %q, want the canonical mapping.txt regardless of order", got)
+	}
+}
+
 func TestBuild_DuplicateMappingWarnsAndKeepsLast(t *testing.T) {
 	m, warnings := Build(
 		nil,

--- a/gradle/artifactmap/merge_test.go
+++ b/gradle/artifactmap/merge_test.go
@@ -1,0 +1,200 @@
+package artifactmap
+
+import (
+	"reflect"
+	"testing"
+)
+
+func TestMerge_DisjointVariantsUnion(t *testing.T) {
+	base, _ := Build(
+		[]File{{DeployPath: deploy("app-demo-release.apk"), SourcePath: demoAPKSource}},
+		nil,
+		[]File{{DeployPath: deploy("mapping.txt"), SourcePath: demoMappingSource}},
+	)
+	overlay, _ := Build(
+		[]File{{DeployPath: deploy("app-paid-release.apk"), SourcePath: paidAPKSource}},
+		nil,
+		[]File{{DeployPath: demoMappingRenamed, SourcePath: paidMappingSource}},
+	)
+
+	merged, warnings := Merge(base, overlay)
+
+	if len(warnings) != 0 {
+		t.Fatalf("unexpected warnings: %v", warnings)
+	}
+	want := map[string]Entry{
+		"demoRelease": {Module: "app", Mapping: "mapping.txt", AAB: []string{}, APK: []string{"app-demo-release.apk"}},
+		"paidRelease": {Module: "app", Mapping: "mapping-20260805121530.txt", AAB: []string{}, APK: []string{"app-paid-release.apk"}},
+	}
+	if !reflect.DeepEqual(merged.Variants, want) {
+		t.Fatalf("Variants = %+v, want %+v", merged.Variants, want)
+	}
+	if merged.Version != Version {
+		t.Fatalf("Version = %d, want %d", merged.Version, Version)
+	}
+}
+
+func TestMerge_RebuiltVariantReplacedWithWarnings(t *testing.T) {
+	base, _ := Build(
+		[]File{{DeployPath: deploy("app-demo-release.apk"), SourcePath: demoAPKSource}},
+		nil,
+		[]File{{DeployPath: deploy("mapping.txt"), SourcePath: demoMappingSource}},
+	)
+	overlay, _ := Build(
+		[]File{{DeployPath: deploy("app-demo-release-20260805.apk"), SourcePath: demoAPKSource}},
+		nil,
+		[]File{{DeployPath: demoMappingRenamed, SourcePath: demoMappingSource}},
+	)
+
+	merged, warnings := Merge(base, overlay)
+
+	if len(warnings) != 2 { // rebuilt APKs + rebuilt mapping
+		t.Fatalf("expected 2 replacement warnings, got %v", warnings)
+	}
+	got := merged.Variants["demoRelease"]
+	if !reflect.DeepEqual(got.APK, []string{"app-demo-release-20260805.apk"}) {
+		t.Fatalf("APK = %v, want the overlay's artifact", got.APK)
+	}
+	if got.Mapping != "mapping-20260805121530.txt" {
+		t.Fatalf("Mapping = %q, want the overlay's mapping", got.Mapping)
+	}
+}
+
+// TestMerge_ApkThenAabRunsCombine: the canonical two-step workflow — one run
+// builds the variant's APK, a later run its AAB. The merged entry must carry
+// both; the second run must not wipe the first's artifacts.
+func TestMerge_ApkThenAabRunsCombine(t *testing.T) {
+	apkRun, _ := Build(
+		[]File{{DeployPath: deploy("app-demo-release.apk"), SourcePath: demoAPKSource}},
+		nil,
+		[]File{{DeployPath: deploy("mapping.txt"), SourcePath: demoMappingSource}},
+	)
+	aabRun, _ := Build(
+		nil,
+		[]File{{DeployPath: deploy("app-demo-release.aab"), SourcePath: demoAABSource}},
+		[]File{{DeployPath: demoMappingRenamed, SourcePath: demoMappingSource}},
+	)
+
+	merged, warnings := Merge(apkRun, aabRun)
+
+	got := merged.Variants["demoRelease"]
+	if !reflect.DeepEqual(got.APK, []string{"app-demo-release.apk"}) {
+		t.Fatalf("APK = %v, the first run's APK must survive the merge", got.APK)
+	}
+	if !reflect.DeepEqual(got.AAB, []string{"app-demo-release.aab"}) {
+		t.Fatalf("AAB = %v, want the second run's AAB", got.AAB)
+	}
+	if got.Mapping != "mapping-20260805121530.txt" {
+		t.Fatalf("Mapping = %q, want the second run's (rebuilt) mapping", got.Mapping)
+	}
+	if len(warnings) != 1 { // only the rebuilt mapping warns
+		t.Fatalf("expected 1 warning for the rebuilt mapping, got %v", warnings)
+	}
+}
+
+func TestMerge_IdenticalVariantNoWarning(t *testing.T) {
+	m, _ := Build(
+		[]File{{DeployPath: deploy("app-demo-release.apk"), SourcePath: demoAPKSource}},
+		nil, nil,
+	)
+
+	merged, warnings := Merge(m, m)
+
+	if len(warnings) != 0 {
+		t.Fatalf("identical maps must merge silently, got %v", warnings)
+	}
+	if !reflect.DeepEqual(merged.Variants, m.Variants) {
+		t.Fatalf("Variants = %+v, want unchanged %+v", merged.Variants, m.Variants)
+	}
+}
+
+// TestMerge_CrossModuleCollisionRekeys: base has a bare "demoRelease" key from
+// module app; the overlay brings module wear's demoRelease. After the merge
+// both must be reachable under module-disambiguated keys.
+func TestMerge_CrossModuleCollisionRekeys(t *testing.T) {
+	base, _ := Build(
+		[]File{{DeployPath: deploy("app-demo-release.apk"), SourcePath: demoAPKSource}},
+		nil, nil,
+	)
+	overlay, _ := Build(
+		[]File{{DeployPath: deploy("wear-demo-release.apk"), SourcePath: wearAPKSource}},
+		nil, nil,
+	)
+
+	merged, warnings := Merge(base, overlay)
+
+	if len(warnings) != 0 {
+		t.Fatalf("unexpected warnings: %v", warnings)
+	}
+	wantKeys := []string{"app/demoRelease", "wear/demoRelease"}
+	if got := merged.SortedVariantKeys(); !reflect.DeepEqual(got, wantKeys) {
+		t.Fatalf("keys = %v, want %v", got, wantKeys)
+	}
+}
+
+func TestMerge_UnmatchedUnionDeduped(t *testing.T) {
+	base := Map{Version: Version, Variants: map[string]Entry{}, Unmatched: Unmatched{
+		APK: []string{"stray.apk"}, AAB: []string{}, Mapping: []string{"stray-mapping.txt"},
+	}}
+	overlay := Map{Version: Version, Variants: map[string]Entry{}, Unmatched: Unmatched{
+		APK: []string{"stray.apk", "another.apk"}, AAB: []string{}, Mapping: []string{},
+	}}
+
+	merged, _ := Merge(base, overlay)
+
+	if want := []string{"another.apk", "stray.apk"}; !reflect.DeepEqual(merged.Unmatched.APK, want) {
+		t.Fatalf("Unmatched.APK = %v, want %v", merged.Unmatched.APK, want)
+	}
+	if want := []string{"stray-mapping.txt"}; !reflect.DeepEqual(merged.Unmatched.Mapping, want) {
+		t.Fatalf("Unmatched.Mapping = %v, want %v", merged.Unmatched.Mapping, want)
+	}
+}
+
+func TestReplaceFile(t *testing.T) {
+	m, _ := Build(
+		[]File{{DeployPath: deploy("app-demo-release.apk"), SourcePath: demoAPKSource}},
+		[]File{{DeployPath: deploy("app-demo-release.aab"), SourcePath: demoAABSource}},
+		[]File{{DeployPath: deploy("mapping.txt"), SourcePath: demoMappingSource}},
+	)
+
+	if !m.ReplaceFile("app-demo-release.aab", "app-demo-release-bitrise-signed.aab") {
+		t.Fatal("expected the AAB reference to be replaced")
+	}
+	if got := m.Variants["demoRelease"].AAB; !reflect.DeepEqual(got, []string{"app-demo-release-bitrise-signed.aab"}) {
+		t.Fatalf("AAB = %v, want the signed name", got)
+	}
+	// mapping references are never touched
+	if m.ReplaceFile("mapping.txt", "other.txt") {
+		t.Fatal("mapping references must not be replaceable")
+	}
+	if m.ReplaceFile("no-such-file.apk", "x.apk") {
+		t.Fatal("expected miss to report false")
+	}
+}
+
+func TestReplaceFile_Unmatched(t *testing.T) {
+	m := Map{Version: Version, Variants: map[string]Entry{}, Unmatched: Unmatched{
+		APK: []string{"stray.apk"}, AAB: []string{}, Mapping: []string{},
+	}}
+
+	if !m.ReplaceFile("stray.apk", "stray-bitrise-signed.apk") {
+		t.Fatal("expected the unmatched APK reference to be replaced")
+	}
+	if !reflect.DeepEqual(m.Unmatched.APK, []string{"stray-bitrise-signed.apk"}) {
+		t.Fatalf("Unmatched.APK = %v", m.Unmatched.APK)
+	}
+}
+
+func TestMarshal_MatchesWrite(t *testing.T) {
+	m, _ := Build(
+		[]File{{DeployPath: deploy("app-demo-release.apk"), SourcePath: demoAPKSource}},
+		nil, nil,
+	)
+	data, err := Marshal(m)
+	if err != nil {
+		t.Fatalf("Marshal: %v", err)
+	}
+	if len(data) == 0 || data[len(data)-1] != '\n' {
+		t.Fatal("Marshal must render the trailing-newline document Write persists")
+	}
+}

--- a/gradle/artifactmap/variant.go
+++ b/gradle/artifactmap/variant.go
@@ -1,0 +1,96 @@
+package artifactmap
+
+import (
+	"path/filepath"
+	"strings"
+)
+
+// ArtifactVariant identifies the build variant an artifact belongs to: the
+// module together with the merged Gradle variant name (for example
+// "demoRelease"). It is only compared between artifacts, so its exact textual
+// form is not a stable contract; an app artifact and the mapping.txt built for
+// the same variant just need to produce equal values. The module is included so
+// artifacts from different modules that share a variant name (for example both
+// producing "release") do not collide.
+type ArtifactVariant struct {
+	Module  string
+	Variant string
+}
+
+// VariantFromPath reports the build variant encoded in a Gradle build-output
+// path. It reconciles the two directory shapes the Android Gradle Plugin uses:
+// APKs split the variant into flavor and build type
+// (build/outputs/apk/demo/release/), while AABs and mapping files use a single
+// merged directory (build/outputs/bundle/demoRelease/,
+// build/outputs/mapping/demoRelease/). Joining the APK's segments yields the
+// same merged name, so an APK and its mapping resolve to equal ArtifactVariants.
+//
+// It anchors on the "outputs" (or "intermediates") directory and reads the
+// artifact kind that follows it, so a flavor directory that happens to be named
+// "apk"/"bundle"/"mapping" is not mistaken for the kind marker. ok is false when
+// the path is not a recognised output or mapping path.
+func VariantFromPath(path string) (variant ArtifactVariant, ok bool) {
+	segments := strings.Split(filepath.ToSlash(path), "/")
+
+	for i := 0; i+1 < len(segments); i++ {
+		if segments[i] != "outputs" && segments[i] != "intermediates" {
+			continue
+		}
+
+		module := moduleFromSegments(segments[:i])
+		switch segments[i+1] {
+		case "apk", "bundle":
+			// The variant is every directory between the kind and the file name.
+			variantSegments := segments[i+2 : len(segments)-1]
+			if len(variantSegments) == 0 {
+				return ArtifactVariant{}, false
+			}
+			return ArtifactVariant{Module: module, Variant: mergeVariantSegments(variantSegments)}, true
+		case "mapping":
+			// The variant is the single directory right after "mapping",
+			// ignoring any deeper "minify..." subdirectory.
+			if i+2 <= len(segments)-2 {
+				return ArtifactVariant{Module: module, Variant: segments[i+2]}, true
+			}
+			return ArtifactVariant{}, false
+		}
+		// Some other "outputs" child (e.g. logs), or a directory named "outputs"
+		// higher up the path: keep scanning for the real marker.
+	}
+
+	return ArtifactVariant{}, false
+}
+
+// moduleFromSegments returns the module directory (the segment right before
+// "build"), or "" when the path has no "build" segment.
+func moduleFromSegments(segments []string) string {
+	for i := len(segments) - 1; i >= 1; i-- {
+		if segments[i] == "build" {
+			return segments[i-1]
+		}
+	}
+	return ""
+}
+
+// mergeVariantSegments joins variant directory segments into the single merged
+// Gradle variant name: the first segment as-is, each following one capitalised
+// on its first letter, so ["demo", "release"] and ["demoRelease"] both yield
+// "demoRelease".
+func mergeVariantSegments(segments []string) string {
+	var builder strings.Builder
+	for i, segment := range segments {
+		if i == 0 {
+			builder.WriteString(segment)
+			continue
+		}
+		builder.WriteString(capitalizeFirst(segment))
+	}
+	return builder.String()
+}
+
+func capitalizeFirst(s string) string {
+	if s == "" {
+		return s
+	}
+	return strings.ToUpper(s[:1]) + s[1:]
+}

--- a/gradle/artifactmap/variant.go
+++ b/gradle/artifactmap/variant.go
@@ -18,44 +18,58 @@ type ArtifactVariant struct {
 }
 
 // VariantFromPath reports the build variant encoded in a Gradle build-output
-// path. It reconciles the two directory shapes the Android Gradle Plugin uses:
+// path. It reconciles the directory shapes the Android Gradle Plugin uses:
 // APKs split the variant into flavor and build type
-// (build/outputs/apk/demo/release/), while AABs and mapping files use a single
-// merged directory (build/outputs/bundle/demoRelease/,
-// build/outputs/mapping/demoRelease/). Joining the APK's segments yields the
-// same merged name, so an APK and its mapping resolve to equal ArtifactVariants.
+// (build/outputs/apk/demo/release/), AABs use a single merged directory
+// (build/outputs/bundle/demoRelease/), and mapping files use either the merged
+// directory (build/outputs/mapping/demoRelease/), the merged directory with a
+// deeper "minify..." task subdirectory (intermediates/mapping/demoRelease/
+// minifyDemoReleaseWithR8/), or the ProGuard-era split shape
+// (outputs/mapping/demo/release/). Joining the split segments yields the same
+// merged name, so an app artifact and its mapping resolve to equal
+// ArtifactVariants.
 //
 // It anchors on the "outputs" (or "intermediates") directory and reads the
-// artifact kind that follows it, so a flavor directory that happens to be named
-// "apk"/"bundle"/"mapping" is not mistaken for the kind marker. ok is false when
-// the path is not a recognised output or mapping path.
+// artifact kind that follows it, scanning RIGHT-TO-LEFT so the marker closest
+// to the file wins: a checkout directory that happens to be called "outputs"
+// higher up the path cannot hijack parsing, and a flavor directory that
+// happens to be named "apk"/"bundle"/"mapping" is not mistaken for the kind
+// marker. ok is false when the path is not a recognised output or mapping
+// path.
 func VariantFromPath(path string) (variant ArtifactVariant, ok bool) {
 	segments := strings.Split(filepath.ToSlash(path), "/")
 
-	for i := 0; i+1 < len(segments); i++ {
+	// segments[len-1] is the file name; the marker must sit at least two
+	// levels above it (kind + at least one variant directory in between).
+	for i := len(segments) - 2; i >= 0; i-- {
 		if segments[i] != "outputs" && segments[i] != "intermediates" {
+			continue
+		}
+
+		// The directories between the kind marker and the file name encode
+		// the variant. An empty list means this "marker" has no room for a
+		// variant (e.g. the file itself is named "apk"): not a real marker,
+		// keep scanning left.
+		variantSegments := segments[i+2 : max(i+2, len(segments)-1)]
+		if len(variantSegments) == 0 {
 			continue
 		}
 
 		module := moduleFromSegments(segments[:i])
 		switch segments[i+1] {
 		case "apk", "bundle":
-			// The variant is every directory between the kind and the file name.
-			variantSegments := segments[i+2 : len(segments)-1]
-			if len(variantSegments) == 0 {
-				return ArtifactVariant{}, false
-			}
 			return ArtifactVariant{Module: module, Variant: mergeVariantSegments(variantSegments)}, true
 		case "mapping":
-			// The variant is the single directory right after "mapping",
-			// ignoring any deeper "minify..." subdirectory.
-			if i+2 <= len(segments)-2 {
-				return ArtifactVariant{Module: module, Variant: segments[i+2]}, true
+			// Drop a trailing shrinker-task directory (e.g.
+			// "minifyDemoReleaseWithR8") so both the merged and the
+			// ProGuard-era split layout reduce to the variant directories.
+			if len(variantSegments) > 1 && strings.HasPrefix(variantSegments[len(variantSegments)-1], "minify") {
+				variantSegments = variantSegments[:len(variantSegments)-1]
 			}
-			return ArtifactVariant{}, false
+			return ArtifactVariant{Module: module, Variant: mergeVariantSegments(variantSegments)}, true
 		}
-		// Some other "outputs" child (e.g. logs), or a directory named "outputs"
-		// higher up the path: keep scanning for the real marker.
+		// Some other "outputs" child (e.g. logs): keep scanning for the real
+		// marker.
 	}
 
 	return ArtifactVariant{}, false

--- a/gradle/artifactmap/variant.go
+++ b/gradle/artifactmap/variant.go
@@ -6,50 +6,40 @@ import (
 )
 
 // ArtifactVariant identifies the build variant an artifact belongs to: the
-// module together with the merged Gradle variant name (for example
-// "demoRelease"). It is only compared between artifacts, so its exact textual
-// form is not a stable contract; an app artifact and the mapping.txt built for
-// the same variant just need to produce equal values. The module is included so
-// artifacts from different modules that share a variant name (for example both
-// producing "release") do not collide.
+// module plus the merged Gradle variant name ("demoRelease"). Its textual form
+// is not a stable contract — an app artifact and the mapping.txt built for the
+// same variant just need to produce equal values. The module prevents
+// same-named variants of different modules from colliding.
 type ArtifactVariant struct {
 	Module  string
 	Variant string
 }
 
 // VariantFromPath reports the build variant encoded in a Gradle build-output
-// path. It reconciles the directory shapes the Android Gradle Plugin uses:
-// APKs split the variant into flavor and build type
-// (build/outputs/apk/demo/release/), AABs use a single merged directory
-// (build/outputs/bundle/demoRelease/), and mapping files use either the merged
-// directory (build/outputs/mapping/demoRelease/), the merged directory with a
-// deeper "minify..." task subdirectory (intermediates/mapping/demoRelease/
-// minifyDemoReleaseWithR8/), or the ProGuard-era split shape
-// (outputs/mapping/demo/release/). Joining the split segments yields the same
-// merged name, so an app artifact and its mapping resolve to equal
-// ArtifactVariants.
+// path, reconciling the layouts the Android Gradle Plugin uses: the split
+// flavor/buildType shape (outputs/apk/demo/release/, ProGuard-era
+// outputs/mapping/demo/release/), the merged shape
+// (outputs/{bundle,mapping}/demoRelease/), and a trailing shrinker-task
+// subdirectory (intermediates/mapping/demoRelease/minifyDemoReleaseWithR8/).
+// Split segments merge into the same name, so an app artifact and its mapping
+// resolve to equal ArtifactVariants.
 //
-// It anchors on the "outputs" (or "intermediates") directory and reads the
-// artifact kind that follows it, scanning RIGHT-TO-LEFT so the marker closest
-// to the file wins: a checkout directory that happens to be called "outputs"
-// higher up the path cannot hijack parsing, and a flavor directory that
-// happens to be named "apk"/"bundle"/"mapping" is not mistaken for the kind
-// marker. ok is false when the path is not a recognised output or mapping
-// path.
+// It anchors on the "outputs"/"intermediates" directory followed by the
+// artifact kind, scanning right-to-left so the marker closest to the file
+// wins — a checkout directory named "outputs", or a flavor named
+// "apk"/"bundle"/"mapping", cannot hijack parsing. ok is false when the path
+// is not a recognised output or mapping path.
 func VariantFromPath(path string) (variant ArtifactVariant, ok bool) {
 	segments := strings.Split(filepath.ToSlash(path), "/")
 
-	// segments[len-1] is the file name; the marker must sit at least two
-	// levels above it (kind + at least one variant directory in between).
 	for i := len(segments) - 2; i >= 0; i-- {
 		if segments[i] != "outputs" && segments[i] != "intermediates" {
 			continue
 		}
 
 		// The directories between the kind marker and the file name encode
-		// the variant. An empty list means this "marker" has no room for a
-		// variant (e.g. the file itself is named "apk"): not a real marker,
-		// keep scanning left.
+		// the variant; none means this is not a real marker (e.g. the file
+		// itself is named "apk"), keep scanning left.
 		variantSegments := segments[i+2 : max(i+2, len(segments)-1)]
 		if len(variantSegments) == 0 {
 			continue
@@ -60,16 +50,13 @@ func VariantFromPath(path string) (variant ArtifactVariant, ok bool) {
 		case "apk", "bundle":
 			return ArtifactVariant{Module: module, Variant: mergeVariantSegments(variantSegments)}, true
 		case "mapping":
-			// Drop a trailing shrinker-task directory (e.g.
-			// "minifyDemoReleaseWithR8") so both the merged and the
-			// ProGuard-era split layout reduce to the variant directories.
+			// drop a trailing shrinker-task dir ("minifyDemoReleaseWithR8")
 			if len(variantSegments) > 1 && strings.HasPrefix(variantSegments[len(variantSegments)-1], "minify") {
 				variantSegments = variantSegments[:len(variantSegments)-1]
 			}
 			return ArtifactVariant{Module: module, Variant: mergeVariantSegments(variantSegments)}, true
 		}
-		// Some other "outputs" child (e.g. logs): keep scanning for the real
-		// marker.
+		// some other outputs child (e.g. logs): keep scanning
 	}
 
 	return ArtifactVariant{}, false

--- a/gradle/artifactmap/variant_test.go
+++ b/gradle/artifactmap/variant_test.go
@@ -1,0 +1,97 @@
+package artifactmap
+
+import "testing"
+
+func TestVariantFromPath(t *testing.T) {
+	tests := []struct {
+		name   string
+		path   string
+		want   ArtifactVariant
+		wantOK bool
+	}{
+		{
+			name:   "AAB with merged variant segment",
+			path:   "/bitrise/src/app/build/outputs/bundle/demoRelease/app-demo-release.aab",
+			want:   ArtifactVariant{Module: "app", Variant: "demoRelease"},
+			wantOK: true,
+		},
+		{
+			name:   "APK with split flavor and build type segments",
+			path:   "/bitrise/src/app/build/outputs/apk/demo/release/app-demo-release.apk",
+			want:   ArtifactVariant{Module: "app", Variant: "demoRelease"},
+			wantOK: true,
+		},
+		{
+			name:   "APK without flavor",
+			path:   "/bitrise/src/app/build/outputs/apk/release/app-release.apk",
+			want:   ArtifactVariant{Module: "app", Variant: "release"},
+			wantOK: true,
+		},
+		{
+			name:   "mapping under outputs",
+			path:   "/bitrise/src/app/build/outputs/mapping/demoRelease/mapping.txt",
+			want:   ArtifactVariant{Module: "app", Variant: "demoRelease"},
+			wantOK: true,
+		},
+		{
+			name:   "mapping under intermediates with minify subdir",
+			path:   "/bitrise/src/app/build/intermediates/mapping/productionRelease/minifyProductionReleaseWithR8/mapping.txt",
+			want:   ArtifactVariant{Module: "app", Variant: "productionRelease"},
+			wantOK: true,
+		},
+		{
+			name:   "different module stays distinct",
+			path:   "/bitrise/src/feature/build/outputs/apk/release/feature-release.apk",
+			want:   ArtifactVariant{Module: "feature", Variant: "release"},
+			wantOK: true,
+		},
+		{
+			name:   "multi dimension flavor merges consistently with mapping",
+			path:   "/bitrise/src/app/build/outputs/apk/demoFree/release/app.apk",
+			want:   ArtifactVariant{Module: "app", Variant: "demoFreeRelease"},
+			wantOK: true,
+		},
+		{
+			name:   "flavor named like the kind marker is not mistaken for it",
+			path:   "/bitrise/src/app/build/outputs/apk/apk/release/app.apk",
+			want:   ArtifactVariant{Module: "app", Variant: "apkRelease"},
+			wantOK: true,
+		},
+		{
+			name:   "unrecognised path",
+			path:   "/bitrise/src/some/random/file.apk",
+			want:   ArtifactVariant{},
+			wantOK: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, ok := VariantFromPath(tt.path)
+			if ok != tt.wantOK {
+				t.Fatalf("VariantFromPath(%q) ok = %v, want %v", tt.path, ok, tt.wantOK)
+			}
+			if got != tt.want {
+				t.Fatalf("VariantFromPath(%q) = %+v, want %+v", tt.path, got, tt.want)
+			}
+		})
+	}
+}
+
+// TestVariantFromPath_PairsAPKWithMapping is the load-bearing guarantee: an APK
+// and the mapping file built for the same variant, laid out by AGP in their
+// differently-shaped directories, must resolve to equal ArtifactVariants so they
+// can be paired.
+func TestVariantFromPath_PairsAPKWithMapping(t *testing.T) {
+	apkVariant, ok := VariantFromPath("/bitrise/src/app/build/outputs/apk/demo/release/app-demo-release.apk")
+	if !ok {
+		t.Fatal("expected APK path to resolve a variant")
+	}
+	mappingVariant, ok := VariantFromPath("/bitrise/src/app/build/outputs/mapping/demoRelease/mapping.txt")
+	if !ok {
+		t.Fatal("expected mapping path to resolve a variant")
+	}
+	if apkVariant != mappingVariant {
+		t.Fatalf("APK variant %+v and mapping variant %+v should match", apkVariant, mappingVariant)
+	}
+}

--- a/gradle/artifactmap/variant_test.go
+++ b/gradle/artifactmap/variant_test.go
@@ -63,6 +63,45 @@ func TestVariantFromPath(t *testing.T) {
 			want:   ArtifactVariant{},
 			wantOK: false,
 		},
+		{
+			// regression: this used to panic (slice bounds out of range)
+			name:   "file named like the kind marker directly under outputs",
+			path:   "/x/outputs/apk",
+			want:   ArtifactVariant{},
+			wantOK: false,
+		},
+		{
+			name:   "file named bundle directly under intermediates",
+			path:   "/x/intermediates/bundle",
+			want:   ArtifactVariant{},
+			wantOK: false,
+		},
+		{
+			// regression: the checkout's own outputs/mapping/... prefix used to
+			// hijack parsing; the marker closest to the file must win
+			name:   "outputs directory in the checkout prefix does not hijack",
+			path:   "/bitrise/src/outputs/mapping/tools/app/build/outputs/apk/release/app.apk",
+			want:   ArtifactVariant{Module: "app", Variant: "release"},
+			wantOK: true,
+		},
+		{
+			name:   "ProGuard-era split flavor mapping merges like its APK",
+			path:   "/bitrise/src/app/build/outputs/mapping/demo/release/mapping.txt",
+			want:   ArtifactVariant{Module: "app", Variant: "demoRelease"},
+			wantOK: true,
+		},
+		{
+			name:   "split flavor mapping with minify subdir",
+			path:   "/bitrise/src/app/build/intermediates/mapping/demo/release/minifyDemoReleaseWithR8/mapping.txt",
+			want:   ArtifactVariant{Module: "app", Variant: "demoRelease"},
+			wantOK: true,
+		},
+		{
+			name:   "variant directory starting with minify is not stripped when alone",
+			path:   "/bitrise/src/app/build/outputs/mapping/minifyme/mapping.txt",
+			want:   ArtifactVariant{Module: "app", Variant: "minifyme"},
+			wantOK: true,
+		},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
## Context

[SSW-3065](https://bitrise.atlassian.net/browse/SSW-3065): multi-variant Android builds export several APK/AAB/mapping files, but the flat `BITRISE_*_PATH` step outputs cannot express which mapping belongs to which artifact — and Google Play accepts exactly one mapping file per version code, so consumers can end up uploading the wrong one.

This adds `gradle/artifactmap`: the shared contract between the producing steps (gradle-runner, android-build) and the consuming step (google-play-deploy) for pairing each variant's artifacts with its own mapping file by identity.

## The document

Written by producers as `android-artifact-map.json` into the deploy dir, exported as `BITRISE_ANDROID_ARTIFACT_MAP_PATH`:

```json
{
  "version": 1,
  "variants": {
    "demoRelease": {
      "module": "app",
      "mapping": "mapping.txt",
      "aab": ["app-demo-release.aab"],
      "apk": ["app-demo-release.apk"]
    }
  },
  "unmatched": { "apk": [], "aab": [], "mapping": [] }
}
```

Design decisions:
- **Variant-keyed** object with explicit typed fields; keys disambiguate as `module/variant` only on cross-module collision (consumers pair by file identity, not by key)
- **File names, not paths**: values resolve against the map file's own directory (`Resolve`), so the document survives the deploy dir being archived/moved, and pairing survives the timestamp-suffix renames the steps apply on name collisions
- **`unmatched`** keeps exported files whose variant can't be derived from their build-output path — visible instead of silently dropped
- **Stdlib-only** so the consumer step vendors just this package
- Variant detection (`VariantFromPath`) anchors on the `outputs`/`intermediates` marker and reconciles the split APK directory shape (`apk/<flavor>/<type>/`) with the merged AAB/mapping shape (`bundle|mapping/<flavorType>/`), so an APK and the mapping built for the same variant resolve to equal values

## Testing

- Table tests for `VariantFromPath` incl. the APK↔mapping pairing guarantee
- `Build` grouping: multi-variant, ABI splits, duplicate-mapping warning, cross-module key collision, unmatched routing
- Write/Read round-trip + an on-disk **document-shape lock test** (schema changes must bump the version)
- Version gating: rejects newer-versioned and non-artifact-map JSON
- Verified end-to-end locally: a two-flavor minified sample built through the updated gradle-runner step produced the map, and the updated google-play-deploy pairing selected each variant's own mapping (including a collision-renamed one)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[SSW-3065]: https://bitrise.atlassian.net/browse/SSW-3065?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ