### PR TITLE
chore: migrate sdk package to go-utils v2

### DIFF
--- a/metaparser/androidartifact/apk_info.go
+++ b/metaparser/androidartifact/apk_info.go
@@ -10,8 +10,12 @@ import (
 
 	"github.com/avast/apkparser"
 	"github.com/bitrise-io/go-android/v2/sdk"
-	"github.com/bitrise-io/go-utils/command"
+	"github.com/bitrise-io/go-utils/v2/command"
+	"github.com/bitrise-io/go-utils/v2/env"
+	"github.com/bitrise-io/go-utils/v2/pathutil"
 )
+
+var cmdFactory = command.NewFactory(env.NewRepository())
 
 func GetAPKInfoWithFallback(logger Logger, apkPth string) (Info, error) {
 	parsedInfo, err := GetAPKInfo(apkPth)
@@ -88,7 +92,7 @@ func GetAPKInfoWithAapt(apkPth string) (Info, error) {
 	sdkModel, err := sdk.NewDefaultModel(sdk.Environment{
 		AndroidHome:    os.Getenv("ANDROID_HOME"),
 		AndroidSDKRoot: os.Getenv("ANDROID_SDK_ROOT"),
-	})
+	}, pathutil.NewPathChecker())
 	if err != nil {
 		return Info{}, fmt.Errorf("failed to create sdk model, error: %s", err)
 	}
@@ -98,7 +102,7 @@ func GetAPKInfoWithAapt(apkPth string) (Info, error) {
 		return Info{}, fmt.Errorf("failed to find latest aapt binary, error: %s", err)
 	}
 
-	aaptOut, err := command.New(aaptPth, "dump", "badging", apkPth).RunAndReturnTrimmedCombinedOutput()
+	aaptOut, err := cmdFactory.Create(aaptPth, []string{"dump", "badging", apkPth}, nil).RunAndReturnTrimmedCombinedOutput()
 	if err != nil {
 		return Info{}, fmt.Errorf("failed to get apk infos, output: %s, error: %s", aaptOut, err)
 	}

--- a/metaparser/androidsignature/signature.go
+++ b/metaparser/androidsignature/signature.go
@@ -11,6 +11,7 @@ import (
 	"github.com/bitrise-io/go-android/v2/sdk"
 	"github.com/bitrise-io/go-utils/v2/command"
 	"github.com/bitrise-io/go-utils/v2/env"
+	"github.com/bitrise-io/go-utils/v2/pathutil"
 )
 
 var cmdFactory = command.NewFactory(env.NewRepository())
@@ -84,7 +85,7 @@ func getV2PlusSignature(pathParams []string) (string, error) {
 	sdkModel, err := sdk.NewDefaultModel(sdk.Environment{
 		AndroidHome:    os.Getenv("ANDROID_HOME"),
 		AndroidSDKRoot: os.Getenv("ANDROID_SDK_ROOT"),
-	})
+	}, pathutil.NewPathChecker())
 	if err != nil {
 		return "", fmt.Errorf("failed to create sdk model, error: %s", err)
 	}

--- a/sdk/sdk.go
+++ b/sdk/sdk.go
@@ -14,6 +14,7 @@ import (
 // Model ...
 type Model struct {
 	androidHome string
+	pathChecker pathutil.PathChecker
 }
 
 // Environment is used to pass in environment variables used to locate Android SDK
@@ -37,17 +38,17 @@ type AndroidSdkInterface interface {
 }
 
 // New creates a Model with a supplied Android SDK path
-func New(androidHome string) (*Model, error) {
-	evaluatedSDKRoot, err := validateAndroidSDKRoot(androidHome)
+func New(androidHome string, pathChecker pathutil.PathChecker) (*Model, error) {
+	evaluatedSDKRoot, err := validateAndroidSDKRoot(androidHome, pathChecker)
 	if err != nil {
 		return nil, err
 	}
 
-	return &Model{androidHome: evaluatedSDKRoot}, nil
+	return &Model{androidHome: evaluatedSDKRoot, pathChecker: pathChecker}, nil
 }
 
 // NewDefaultModel locates Android SDK based on environement variables
-func NewDefaultModel(envs Environment) (*Model, error) {
+func NewDefaultModel(envs Environment, pathChecker pathutil.PathChecker) (*Model, error) {
 	// https://developer.android.com/studio/command-line/variables#envar
 	// Sets the path to the SDK installation directory.
 	// ANDROID_HOME, which also points to the SDK installation directory, is deprecated.
@@ -61,25 +62,25 @@ func NewDefaultModel(envs Environment) (*Model, error) {
 			continue
 		}
 
-		evaluatedSDKRoot, err := validateAndroidSDKRoot(SDKdir)
+		evaluatedSDKRoot, err := validateAndroidSDKRoot(SDKdir, pathChecker)
 		if err != nil {
 			warnings = append(warnings, err.Error())
 			continue
 		}
 
-		return &Model{androidHome: evaluatedSDKRoot}, nil
+		return &Model{androidHome: evaluatedSDKRoot, pathChecker: pathChecker}, nil
 	}
 
 	return nil, fmt.Errorf("could not locate Android SDK root directory: %s", warnings)
 }
 
-func validateAndroidSDKRoot(androidSDKRoot string) (string, error) {
+func validateAndroidSDKRoot(androidSDKRoot string, pathChecker pathutil.PathChecker) (string, error) {
 	evaluatedSDKRoot, err := filepath.EvalSymlinks(androidSDKRoot)
 	if err != nil {
 		return "", err
 	}
 
-	if exist, err := pathutil.NewPathChecker().IsDirExists(evaluatedSDKRoot); err != nil {
+	if exist, err := pathChecker.IsDirExists(evaluatedSDKRoot); err != nil {
 		return "", err
 	} else if !exist {
 		return "", fmt.Errorf("(%s) is not a valid Android SDK root", evaluatedSDKRoot)
@@ -131,7 +132,7 @@ func (model *Model) LatestBuildToolPath(name string) (string, error) {
 	}
 
 	pth := filepath.Join(buildToolsDir, name)
-	if exist, err := pathutil.NewPathChecker().IsPathExists(pth); err != nil {
+	if exist, err := model.pathChecker.IsPathExists(pth); err != nil {
 		return "", err
 	} else if !exist {
 		return "", fmt.Errorf("tool (%s) not found at: %s", name, buildToolsDir)
@@ -161,7 +162,7 @@ func (model *Model) CmdlineToolsPath() (string, error) {
 		}
 
 		sdkmanagerPath := matches[0]
-		if exists, err := pathutil.NewPathChecker().IsDirExists(sdkmanagerPath); err != nil {
+		if exists, err := model.pathChecker.IsDirExists(sdkmanagerPath); err != nil {
 			warnings = append(warnings, fmt.Sprintf("failed to validate path (%s): %v", sdkmanagerPath, err))
 			continue
 		} else if !exists {

--- a/sdk/sdk_test.go
+++ b/sdk/sdk_test.go
@@ -6,13 +6,13 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/bitrise-io/go-utils/fileutil"
-	"github.com/bitrise-io/go-utils/pathutil"
+	"github.com/bitrise-io/go-utils/v2/fileutil"
+	"github.com/bitrise-io/go-utils/v2/pathutil"
 	"github.com/stretchr/testify/require"
 )
 
 func TestLatestBuildToolsDir(t *testing.T) {
-	tmpDir, err := pathutil.NormalizedOSTempDirPath("")
+	tmpDir, err := pathutil.NewPathProvider().CreateTempDir("")
 	require.NoError(t, err)
 
 	buildToolsVersions := []string{"25.0.2", "25.0.3", "22.0.4"}
@@ -21,7 +21,7 @@ func TestLatestBuildToolsDir(t *testing.T) {
 		require.NoError(t, os.MkdirAll(buildToolsVersionPth, 0700))
 	}
 
-	sdk, err := New(tmpDir)
+	sdk, err := New(tmpDir, pathutil.NewPathChecker())
 	require.NoError(t, err)
 
 	latestBuildToolsDir, err := sdk.LatestBuildToolsDir()
@@ -30,10 +30,10 @@ func TestLatestBuildToolsDir(t *testing.T) {
 }
 
 func TestNoBuildToolsDir(t *testing.T) {
-	tmpDir, err := pathutil.NormalizedOSTempDirPath("")
+	tmpDir, err := pathutil.NewPathProvider().CreateTempDir("")
 	require.NoError(t, err)
 
-	sdk, err := New(tmpDir)
+	sdk, err := New(tmpDir, pathutil.NewPathChecker())
 	require.NoError(t, err)
 
 	_, err = sdk.LatestBuildToolsDir()
@@ -41,7 +41,7 @@ func TestNoBuildToolsDir(t *testing.T) {
 }
 
 func TestLatestBuildToolPath(t *testing.T) {
-	tmpDir, err := pathutil.NormalizedOSTempDirPath("")
+	tmpDir, err := pathutil.NewPathProvider().CreateTempDir("")
 	require.NoError(t, err)
 
 	buildToolsVersions := []string{"25.0.2", "25.0.3", "22.0.4"}
@@ -52,9 +52,9 @@ func TestLatestBuildToolPath(t *testing.T) {
 
 	latestBuildToolsVersions := filepath.Join(tmpDir, "build-tools", "25.0.3")
 	zipalignPth := filepath.Join(latestBuildToolsVersions, "zipalign")
-	require.NoError(t, fileutil.WriteStringToFile(zipalignPth, ""))
+	require.NoError(t, fileutil.NewFileManager().Write(zipalignPth, "", 0600))
 
-	sdk, err := New(tmpDir)
+	sdk, err := New(tmpDir, pathutil.NewPathChecker())
 	require.NoError(t, err)
 
 	t.Log("zipalign - exist")
@@ -98,6 +98,7 @@ func TestNewDefaultModel(t *testing.T) {
 			},
 			want: &Model{
 				androidHome: androidHome,
+				pathChecker: pathutil.NewPathChecker(),
 			},
 		},
 		{
@@ -108,6 +109,7 @@ func TestNewDefaultModel(t *testing.T) {
 			},
 			want: &Model{
 				androidHome: androidHome,
+				pathChecker: pathutil.NewPathChecker(),
 			},
 		},
 		{
@@ -118,6 +120,7 @@ func TestNewDefaultModel(t *testing.T) {
 			},
 			want: &Model{
 				androidHome: sdkRoot,
+				pathChecker: pathutil.NewPathChecker(),
 			},
 		},
 		{
@@ -137,7 +140,7 @@ func TestNewDefaultModel(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got, err := NewDefaultModel(tt.envs)
+			got, err := NewDefaultModel(tt.envs, pathutil.NewPathChecker())
 
 			if tt.wantErr {
 				require.Error(t, err)
@@ -211,6 +214,7 @@ func TestModel_CmdlineToolsPath(t *testing.T) {
 
 			model := &Model{
 				androidHome: SDKRoot,
+				pathChecker: pathutil.NewPathChecker(),
 			}
 			want := ""
 			if !tt.wantErr {

--- a/sdkmanager/sdkmanager_test.go
+++ b/sdkmanager/sdkmanager_test.go
@@ -8,6 +8,7 @@ import (
 	"github.com/bitrise-io/go-android/v2/sdk"
 	"github.com/bitrise-io/go-utils/v2/command"
 	"github.com/bitrise-io/go-utils/v2/env"
+	"github.com/bitrise-io/go-utils/v2/pathutil"
 	"github.com/stretchr/testify/require"
 )
 
@@ -69,7 +70,7 @@ func TestNew(t *testing.T) {
 				}
 			}
 
-			sdk, err := sdk.New(sdkRoot)
+			sdk, err := sdk.New(sdkRoot, pathutil.NewPathChecker())
 			if err != nil {
 				t.Fatalf("failed to create sdk: %v", err)
 			}


### PR DESCRIPTION
## Summary

- Use injected pathChecker in sdk/sdk.go. Drop remaining pathutil.NewPathChecker() calls.
- Migrate command to v2 in metaparser/androidartifact/apk_info.go. Add cmdFactory.
- Migrate fileutil to v2 in sdk/sdk_test.go.

## Test

`go build/test/vet/mod tidy` was ran.
