### PR TITLE
Removes v1 imports into metaparser

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -8,7 +8,7 @@ require (
 	github.com/bitrise-io/go-steputils v1.0.6
 	github.com/bitrise-io/go-steputils/v2 v2.0.0-alpha.49
 	github.com/bitrise-io/go-utils v1.0.15
-	github.com/bitrise-io/go-utils/v2 v2.0.0-alpha.34
+	github.com/bitrise-io/go-utils/v2 v2.0.0-alpha.36
 	github.com/hashicorp/go-version v1.7.0
 	github.com/kr/pretty v0.3.1
 	github.com/lwithers/minijks v1.1.0

--- a/go.mod
+++ b/go.mod
@@ -24,6 +24,7 @@ require (
 	github.com/kr/text v0.2.0 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/rogpeppe/go-internal v1.9.0 // indirect
+	github.com/stretchr/objx v0.5.2 // indirect
 	golang.org/x/crypto v0.33.0 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -9,8 +9,8 @@ github.com/bitrise-io/go-steputils/v2 v2.0.0-alpha.49/go.mod h1:hK2zMovlJg7+FLdJ
 github.com/bitrise-io/go-utils v1.0.1/go.mod h1:ZY1DI+fEpZuFpO9szgDeICM4QbqoWVt0RSY3tRI1heY=
 github.com/bitrise-io/go-utils v1.0.15 h1:KRQjNiPrkxBRM6G5fQy05v0p0r8wycWfKVb+Ko+Vtg0=
 github.com/bitrise-io/go-utils v1.0.15/go.mod h1:ZY1DI+fEpZuFpO9szgDeICM4QbqoWVt0RSY3tRI1heY=
-github.com/bitrise-io/go-utils/v2 v2.0.0-alpha.34 h1:xsLfhItfs4SCCAesbv7UtKpldNqievDvtHggSuBI2+w=
-github.com/bitrise-io/go-utils/v2 v2.0.0-alpha.34/go.mod h1:5Z/vkUZ2BIY7IAVlMGns3ypRjd+J872YBSCJaLWVo/U=
+github.com/bitrise-io/go-utils/v2 v2.0.0-alpha.36 h1:zbvo84Wun4urzBt6+tkGpYSDvA5TwCfsNj4HEKvppnk=
+github.com/bitrise-io/go-utils/v2 v2.0.0-alpha.36/go.mod h1:5Z/vkUZ2BIY7IAVlMGns3ypRjd+J872YBSCJaLWVo/U=
 github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ33E=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=

--- a/metaparser/aab.go
+++ b/metaparser/aab.go
@@ -7,7 +7,7 @@ import (
 
 // ParseAABData ...
 func (m *Parser) ParseAABData(pth string) (*ArtifactMetadata, error) {
-	aabInfo, err := androidartifact.GetAABInfo(m.bundletoolPath, pth)
+	aabInfo, err := androidartifact.GetAABInfo(m.cmdFactory, m.bundletoolPath, pth)
 	if err != nil {
 		m.logger.Warnf("Failed to parse AAB info: %s", err)
 		m.logger.AABParseWarnf("aab-parse", "aabparser package failed to parse AAB, error: %s", err)

--- a/metaparser/androidartifact/aab_info.go
+++ b/metaparser/androidartifact/aab_info.go
@@ -6,11 +6,12 @@ import (
 	"strings"
 
 	"github.com/bitrise-io/go-android/v2/metaparser/bundletool"
+	"github.com/bitrise-io/go-utils/v2/command"
 )
 
 // GetAABInfo returns infos about the AAB.
-func GetAABInfo(bt bundletool.Path, aabPath string) (Info, error) {
-	manifestContent, err := bt.Exec("dump", "manifest", "--bundle", aabPath)
+func GetAABInfo(cmdFactory command.Factory, bt bundletool.Path, aabPath string) (Info, error) {
+	manifestContent, err := bt.Exec(cmdFactory, "dump", "manifest", "--bundle", aabPath)
 	if err != nil {
 		return Info{}, err
 	}
@@ -20,7 +21,7 @@ func GetAABInfo(bt bundletool.Path, aabPath string) (Info, error) {
 	appName := getAppNameFromManifest(manifestContent)
 
 	if strings.HasPrefix(appName, "@") {
-		resourcesContent, err := bt.Exec("dump", "resources", "--bundle", aabPath, "--resource", appName[1:], "--values")
+		resourcesContent, err := bt.Exec(cmdFactory, "dump", "resources", "--bundle", aabPath, "--resource", appName[1:], "--values")
 		if err != nil {
 			return Info{}, err
 		}

--- a/metaparser/androidartifact/aab_info_test.go
+++ b/metaparser/androidartifact/aab_info_test.go
@@ -1,42 +1,32 @@
 package androidartifact
 
 import (
-	"os"
-	"path"
-	"path/filepath"
+	"slices"
 	"strings"
 	"testing"
 
 	"github.com/bitrise-io/go-android/v2/metaparser/bundletool"
-	"github.com/bitrise-io/go-android/v2/metaparser/github"
-	"github.com/bitrise-io/go-utils/v2/log"
+	"github.com/bitrise-io/go-utils/v2/mocks"
 	"github.com/kr/pretty"
+	"github.com/stretchr/testify/mock"
 )
 
 func Test_GetAABInfo(t *testing.T) {
-	contents, err := github.FetchFile(
-		"bitrise-io",
-		"sample-artifacts",
-		path.Join("aab", "app-weak-algorithm-signed.aab"),
-		"master",
-		os.Getenv("GITHUB_TOKEN"),
-	)
-	if err != nil {
-		t.Fatalf("failed to fetch test artifact: %s", err)
-	}
+	manifestCmd := mocks.NewCommand(t)
+	manifestCmd.On("RunAndReturnTrimmedCombinedOutput").Return(testAABArtifactAndroidManifest, nil)
 
-	tmpDir := t.TempDir()
-	aabPath := filepath.Join(tmpDir, "temp.aab")
-	if err := os.WriteFile(aabPath, contents, os.ModePerm); err != nil {
-		t.Fatalf("failed to write file, error: %s", err)
-	}
+	resourcesCmd := mocks.NewCommand(t)
+	resourcesCmd.On("RunAndReturnTrimmedCombinedOutput").Return(`"en" "sample-apps-android-simple"`, nil)
 
-	bt, err := bundletool.New(log.NewLogger(), "1.15.0")
-	if err != nil {
-		t.Fatalf("setup: failed to initialize bundletool, error: %s", err)
-	}
+	cmdFactory := mocks.NewFactory(t)
+	cmdFactory.On("Create", mock.Anything, mock.MatchedBy(func(args []string) bool {
+		return slices.Contains(args, "resources")
+	}), mock.Anything).Return(resourcesCmd)
+	cmdFactory.On("Create", mock.Anything, mock.Anything, mock.Anything).Return(manifestCmd)
 
-	got, err := GetAABInfo(bt, aabPath)
+	bt := bundletool.Path("fake-bundletool-all.jar")
+
+	got, err := GetAABInfo(cmdFactory, bt, "fake.aab")
 	if err != nil {
 		t.Fatalf("GetAABInfo() error = %v", err)
 	}
@@ -59,28 +49,30 @@ func Test_GetAABInfo(t *testing.T) {
 	}
 }
 
+// testAABArtifactAndroidManifest is the manifest `bundletool dump manifest` would print
+// for a real AAB; used here as canned output for the fake command factory.
 const testAABArtifactAndroidManifest string = `<manifest xmlns:android="http://schemas.android.com/apk/res/android" android:versionCode="189" android:versionName="1.0" package="com.bitrise_io.sample_apps_android_simple" platformBuildVersionCode="189" platformBuildVersionName="1.0">
-      
+
   <uses-sdk android:minSdkVersion="15" android:targetSdkVersion="26"/>
-      
+
   <application android:allowBackup="true" android:icon="@mipmap/ic_launcher" android:label="@string/app_name" android:supportsRtl="true" android:theme="@style/AppTheme">
-            
+
     <activity android:label="@string/app_name" android:name="com.bitrise_io.sample_apps_android_simple.MainActivity">
-                  
+
       <intent-filter>
-                        
+
         <action android:name="android.intent.action.MAIN"/>
-                        
+
         <category android:name="android.intent.category.LAUNCHER"/>
-                    
+
       </intent-filter>
-              
+
     </activity>
-            
+
     <meta-data android:name="android.support.VERSION" android:value="26.1.0"/>
-            
+
     <meta-data android:name="android.arch.lifecycle.VERSION" android:value="27.0.0-SNAPSHOT"/>
-        
+
   </application>
-  
+
 </manifest>`

--- a/metaparser/androidartifact/aab_info_test.go
+++ b/metaparser/androidartifact/aab_info_test.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/bitrise-io/go-android/v2/metaparser/bundletool"
 	"github.com/bitrise-io/go-android/v2/metaparser/github"
+	"github.com/bitrise-io/go-utils/v2/log"
 	"github.com/kr/pretty"
 )
 
@@ -30,7 +31,7 @@ func Test_GetAABInfo(t *testing.T) {
 		t.Fatalf("failed to write file, error: %s", err)
 	}
 
-	bt, err := bundletool.New("1.15.0")
+	bt, err := bundletool.New(log.NewLogger(), "1.15.0")
 	if err != nil {
 		t.Fatalf("setup: failed to initialize bundletool, error: %s", err)
 	}

--- a/metaparser/androidartifact/apk_info.go
+++ b/metaparser/androidartifact/apk_info.go
@@ -4,33 +4,33 @@ import (
 	"bytes"
 	"encoding/xml"
 	"fmt"
-	"os"
 	"strings"
 	"unicode"
 
 	"github.com/avast/apkparser"
-	"github.com/bitrise-io/go-android/v2/sdk"
 	"github.com/bitrise-io/go-utils/v2/command"
-	"github.com/bitrise-io/go-utils/v2/env"
-	"github.com/bitrise-io/go-utils/v2/pathutil"
 )
 
-var cmdFactory = command.NewFactory(env.NewRepository())
+// SDKLocator resolves the path to an installed Android SDK build tool binary.
+// *sdk.Model (github.com/bitrise-io/go-android/v2/sdk) satisfies this.
+type SDKLocator interface {
+	LatestBuildToolPath(name string) (string, error)
+}
 
-func GetAPKInfoWithFallback(logger Logger, apkPth string) (Info, error) {
+func GetAPKInfoWithFallback(logger Logger, cmdFactory command.Factory, sdkModel SDKLocator, apkPth string) (Info, error) {
 	parsedInfo, err := GetAPKInfo(apkPth)
 	if err != nil {
 		logger.Warnf("Falling back to aapt, failed to parse APK info: %s", err)
 		logger.APKParseWarnf("apk-parse", "apkparser package failed to parse APK, error: %s", err)
 
-		return GetAPKInfoWithAapt(apkPth)
+		return GetAPKInfoWithAapt(cmdFactory, sdkModel, apkPth)
 	}
 
 	if strings.ContainsRune(parsedInfo.AppName, unicode.ReplacementChar) {
 		logger.Warnf("Falling back to aapt, failed to parse app name (%s) with Unicode characters.", parsedInfo.AppName)
 		logger.APKParseWarnf("apk-parse", "apkparser package failed to parse Unicode characters in app name: %s", parsedInfo.AppName)
 
-		return GetAPKInfoWithAapt(apkPth)
+		return GetAPKInfoWithAapt(cmdFactory, sdkModel, apkPth)
 	}
 
 	return parsedInfo, nil
@@ -88,15 +88,7 @@ func GetAPKInfo(apkPath string) (Info, error) {
 	}, nil
 }
 
-func GetAPKInfoWithAapt(apkPth string) (Info, error) {
-	sdkModel, err := sdk.NewDefaultModel(sdk.Environment{
-		AndroidHome:    os.Getenv("ANDROID_HOME"),
-		AndroidSDKRoot: os.Getenv("ANDROID_SDK_ROOT"),
-	}, pathutil.NewPathChecker())
-	if err != nil {
-		return Info{}, fmt.Errorf("failed to create sdk model, error: %s", err)
-	}
-
+func GetAPKInfoWithAapt(cmdFactory command.Factory, sdkModel SDKLocator, apkPth string) (Info, error) {
 	aaptPth, err := sdkModel.LatestBuildToolPath("aapt")
 	if err != nil {
 		return Info{}, fmt.Errorf("failed to find latest aapt binary, error: %s", err)

--- a/metaparser/androidartifact/apk_info_test.go
+++ b/metaparser/androidartifact/apk_info_test.go
@@ -6,6 +6,8 @@ import (
 	"testing"
 
 	"github.com/bitrise-io/go-android/v2/metaparser/github"
+	"github.com/bitrise-io/go-utils/v2/mocks"
+	"github.com/stretchr/testify/mock"
 )
 
 const testArtifactAndroidManifest string = `<manifest xmlns:android="http://schemas.android.com/apk/res/android" android:versionCode="1" android:versionName="1.0" package="com.example.birmachera.myapplication">
@@ -21,8 +23,34 @@ const testArtifactAndroidManifest string = `<manifest xmlns:android="http://sche
 	</application>
 </manifest>`
 
+// fakeAaptDumpBadgingOutput is what `aapt dump badging` would print for the
+// "apk with unicode app name" fixture; used to exercise the aapt fallback path
+// without needing an installed Android SDK.
+const fakeAaptDumpBadgingOutput = `package: name='com.example.myapplicationUnicode' versionCode='1' versionName='1.0'
+sdkVersion:'33'
+application-label:'My Application Unicode 🤪'
+application: label='My Application Unicode 🤪' icon='res/mipmap-mdpi-v4/ic_launcher.png'`
+
+// fakeSDKLocator satisfies SDKLocator without requiring an installed Android SDK.
+type fakeSDKLocator struct {
+	path string
+	err  error
+}
+
+func (f fakeSDKLocator) LatestBuildToolPath(_ string) (string, error) {
+	return f.path, f.err
+}
+
 func TestGetAPKInfoWithFallback(t *testing.T) {
 	tLogger := &testLogger{}
+
+	aaptCmd := mocks.NewCommand(t)
+	aaptCmd.On("RunAndReturnTrimmedCombinedOutput").Return(fakeAaptDumpBadgingOutput, nil)
+
+	cmdFactory := mocks.NewFactory(t)
+	cmdFactory.On("Create", mock.Anything, mock.Anything, mock.Anything).Return(aaptCmd)
+
+	sdkModel := fakeSDKLocator{path: "aapt"}
 
 	tests := []struct {
 		name    string
@@ -74,7 +102,7 @@ func TestGetAPKInfoWithFallback(t *testing.T) {
 				t.Fatalf("failed to write file, error: %s", err)
 			}
 
-			got, err := GetAPKInfoWithFallback(tLogger, apkPath)
+			got, err := GetAPKInfoWithFallback(tLogger, cmdFactory, sdkModel, apkPath)
 			if (err != nil) != tt.wantErr {
 				t.Errorf("GetAPKInfoWithFallback() error = %v, wantErr %v", err, tt.wantErr)
 				return

--- a/metaparser/androidartifact/file_name.go
+++ b/metaparser/androidartifact/file_name.go
@@ -7,8 +7,8 @@ import (
 	"strings"
 	"unicode"
 
-	"github.com/bitrise-io/go-utils/pretty"
 	"github.com/bitrise-io/go-utils/v2/log"
+	"github.com/bitrise-io/go-utils/v2/pretty"
 )
 
 const universalSplitParam = "universal"

--- a/metaparser/androidartifact/file_name_test.go
+++ b/metaparser/androidartifact/file_name_test.go
@@ -4,7 +4,7 @@ import (
 	"reflect"
 	"testing"
 
-	"github.com/bitrise-io/go-utils/pretty"
+	"github.com/bitrise-io/go-utils/v2/pretty"
 )
 
 func TestParseArtifactPath(t *testing.T) {

--- a/metaparser/apk.go
+++ b/metaparser/apk.go
@@ -7,7 +7,7 @@ import (
 
 // ParseAPKData ...
 func (m *Parser) ParseAPKData(pth string) (*ArtifactMetadata, error) {
-	apkInfo, err := androidartifact.GetAPKInfoWithFallback(m.logger, pth)
+	apkInfo, err := androidartifact.GetAPKInfoWithFallback(m.logger, m.cmdFactory, m.sdkModel, pth)
 	if err != nil {
 		return nil, err
 	}

--- a/metaparser/bundletool/bundletool.go
+++ b/metaparser/bundletool/bundletool.go
@@ -8,33 +8,27 @@ import (
 	"path/filepath"
 
 	"github.com/bitrise-io/go-utils/v2/command"
-	"github.com/bitrise-io/go-utils/v2/env"
 	"github.com/bitrise-io/go-utils/v2/filedownloader"
-	"github.com/bitrise-io/go-utils/v2/log"
 	"github.com/bitrise-io/go-utils/v2/pathutil"
 )
-
-var cmdFactory = command.NewFactory(env.NewRepository())
 
 // Path ...
 type Path string
 
 // New ...
-func New(logger log.Logger, version string) (Path, error) {
+func New(downloader filedownloader.Downloader, version string) (Path, error) {
 	return fetchAny(
-		logger,
+		downloader,
 		"https://github.com/google/bundletool/releases/download/"+version+"/bundletool-all-"+version+".jar",
 		"https://github.com/google/bundletool/releases/download/"+version+"/bundletool-all.jar",
 	)
 }
 
-func fetchAny(logger log.Logger, source string, fallbackSources ...string) (Path, error) {
+func fetchAny(downloader filedownloader.Downloader, source string, fallbackSources ...string) (Path, error) {
 	tmpPth, err := pathutil.NewPathProvider().CreateTempDir("tool")
 	if err != nil {
 		return "", err
 	}
-
-	downloader := filedownloader.NewDownloader(logger)
 
 	toolPath := filepath.Join(tmpPth, "bundletool-all.jar")
 	if err := downloader.DownloadWithFallback(context.Background(), toolPath, source, fallbackSources...); err != nil {
@@ -45,13 +39,13 @@ func fetchAny(logger log.Logger, source string, fallbackSources ...string) (Path
 }
 
 // Command ...
-func (p Path) Command(cmd string, args ...string) command.Command {
+func (p Path) Command(cmdFactory command.Factory, cmd string, args ...string) command.Command {
 	return cmdFactory.Create("java", append([]string{"-Djdk.util.zip.disableZip64ExtraFieldValidation=true", "-jar", string(p), cmd}, args...), nil)
 }
 
 // Exec ...
-func (p Path) Exec(cmd string, args ...string) (string, error) {
-	c := p.Command(cmd, args...)
+func (p Path) Exec(cmdFactory command.Factory, cmd string, args ...string) (string, error) {
+	c := p.Command(cmdFactory, cmd, args...)
 
 	out, err := c.RunAndReturnTrimmedCombinedOutput()
 	if err != nil {

--- a/metaparser/bundletool/bundletool.go
+++ b/metaparser/bundletool/bundletool.go
@@ -1,47 +1,52 @@
 package bundletool
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"os/exec"
 	"path/filepath"
 
-	"github.com/bitrise-io/go-utils/command"
-	"github.com/bitrise-io/go-utils/filedownloader"
-	"github.com/bitrise-io/go-utils/pathutil"
-	"github.com/bitrise-io/go-utils/retry"
+	"github.com/bitrise-io/go-utils/v2/command"
+	"github.com/bitrise-io/go-utils/v2/env"
+	"github.com/bitrise-io/go-utils/v2/filedownloader"
+	"github.com/bitrise-io/go-utils/v2/log"
+	"github.com/bitrise-io/go-utils/v2/pathutil"
 )
+
+var cmdFactory = command.NewFactory(env.NewRepository())
 
 // Path ...
 type Path string
 
 // New ...
-func New(version string) (Path, error) {
+func New(logger log.Logger, version string) (Path, error) {
 	return fetchAny(
+		logger,
 		"https://github.com/google/bundletool/releases/download/"+version+"/bundletool-all-"+version+".jar",
 		"https://github.com/google/bundletool/releases/download/"+version+"/bundletool-all.jar",
 	)
 }
 
-func fetchAny(source string, fallbackSources ...string) (Path, error) {
-	tmpPth, err := pathutil.NormalizedOSTempDirPath("tool")
+func fetchAny(logger log.Logger, source string, fallbackSources ...string) (Path, error) {
+	tmpPth, err := pathutil.NewPathProvider().CreateTempDir("tool")
 	if err != nil {
 		return "", err
 	}
 
-	downloader := filedownloader.New(retry.NewHTTPClient().StandardClient())
+	downloader := filedownloader.NewDownloader(logger)
 
 	toolPath := filepath.Join(tmpPth, "bundletool-all.jar")
-	if err := downloader.GetWithFallback(toolPath, source, fallbackSources...); err != nil {
+	if err := downloader.DownloadWithFallback(context.Background(), toolPath, source, fallbackSources...); err != nil {
 		return "", err
 	}
 
-	return Path(toolPath), err
+	return Path(toolPath), nil
 }
 
 // Command ...
-func (p Path) Command(cmd string, args ...string) *command.Model {
-	return command.New("java", append([]string{"-Djdk.util.zip.disableZip64ExtraFieldValidation=true", "-jar", string(p), cmd}, args...)...)
+func (p Path) Command(cmd string, args ...string) command.Command {
+	return cmdFactory.Create("java", append([]string{"-Djdk.util.zip.disableZip64ExtraFieldValidation=true", "-jar", string(p), cmd}, args...), nil)
 }
 
 // Exec ...

--- a/metaparser/bundletool/bundletool_test.go
+++ b/metaparser/bundletool/bundletool_test.go
@@ -5,6 +5,7 @@ import (
 	"net/http/httptest"
 	"testing"
 
+	"github.com/bitrise-io/go-utils/v2/filedownloader"
 	"github.com/bitrise-io/go-utils/v2/log"
 	"github.com/stretchr/testify/assert"
 )
@@ -64,7 +65,8 @@ func Test_fetchAny(t *testing.T) {
 			}
 			t.Logf("source: %s, fallbackSources: %s", ts1.URL, fallbackURLs)
 
-			got, err := fetchAny(log.NewLogger(), ts1.URL, fallbackURLs...)
+			downloader := filedownloader.NewDownloader(log.NewLogger())
+			got, err := fetchAny(downloader, ts1.URL, fallbackURLs...)
 			if (err != nil) != tt.wantErr {
 				t.Errorf("fetchAny() error = %v, wantErr %v", err, tt.wantErr)
 				return

--- a/metaparser/bundletool/bundletool_test.go
+++ b/metaparser/bundletool/bundletool_test.go
@@ -5,6 +5,7 @@ import (
 	"net/http/httptest"
 	"testing"
 
+	"github.com/bitrise-io/go-utils/v2/log"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -63,7 +64,7 @@ func Test_fetchAny(t *testing.T) {
 			}
 			t.Logf("source: %s, fallbackSources: %s", ts1.URL, fallbackURLs)
 
-			got, err := fetchAny(ts1.URL, fallbackURLs...)
+			got, err := fetchAny(log.NewLogger(), ts1.URL, fallbackURLs...)
 			if (err != nil) != tt.wantErr {
 				t.Errorf("fetchAny() error = %v, wantErr %v", err, tt.wantErr)
 				return

--- a/metaparser/metaparser.go
+++ b/metaparser/metaparser.go
@@ -3,6 +3,7 @@ package metaparser
 import (
 	"github.com/bitrise-io/go-android/v2/metaparser/androidartifact"
 	"github.com/bitrise-io/go-android/v2/metaparser/bundletool"
+	"github.com/bitrise-io/go-utils/v2/command"
 	"github.com/bitrise-io/go-utils/v2/fileutil"
 )
 
@@ -20,13 +21,17 @@ type Parser struct {
 	logger         androidartifact.Logger
 	bundletoolPath bundletool.Path
 	fileManager    fileutil.FileManager
+	cmdFactory     command.Factory
+	sdkModel       androidartifact.SDKLocator
 }
 
 // New ...
-func New(logger androidartifact.Logger, bundletoolPath bundletool.Path, fileManager fileutil.FileManager) *Parser {
+func New(logger androidartifact.Logger, bundletoolPath bundletool.Path, fileManager fileutil.FileManager, cmdFactory command.Factory, sdkModel androidartifact.SDKLocator) *Parser {
 	return &Parser{
 		logger:         logger,
 		bundletoolPath: bundletoolPath,
 		fileManager:    fileManager,
+		cmdFactory:     cmdFactory,
+		sdkModel:       sdkModel,
 	}
 }


### PR DESCRIPTION
* Use exclusively go-utils v2 imports in the metaparser package
* With v2, we can now introduce more dependency injection and use test doubles